### PR TITLE
Pass a real function instead of a js string to dicom-curate as a spec…

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "generate:unitTestSample": "tsx scripts/generateSampleDicomData.ts"
   },
   "dependencies": {
+    "acorn": "^8.14.1",
+    "acorn-globals": "^7.0.1",
     "dcmjs": "^0.38.3",
     "iso8601-duration": "^2.1.2",
     "js-sha256": "^0.11.0",
@@ -64,6 +66,7 @@
     "node-fetch": "^3.3.2",
     "prettier": "^3.4.2",
     "tsx": "^4.19.3",
+    "typescript": "^5.8.3",
     "xml2js": "^0.6.2"
   },
   "license": "MIT",

--- a/scripts/generateSampleSpec.ts
+++ b/scripts/generateSampleSpec.ts
@@ -3,76 +3,70 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { join, relative, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import ts from 'typescript'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 // ——— Paths ———
-const inputPath = join(
+const tsSourcePath = join(
+  __dirname,
+  '..',
+  'src',
+  'config',
+  'sampleBatchCurationSpecification.ts',
+)
+const jsOutPath = join(
   __dirname,
   '..',
   'testdata',
   'sampleCurationSpecification.js',
 )
-const outputTsPath = join(
-  __dirname,
-  '..',
-  'src',
-  'config',
-  'sampleSpecification.ts',
-)
 const readmePath = join(__dirname, '..', 'README.md')
 
-// ——— Read the source file ———
-const content = readFileSync(inputPath, 'utf8').trim()
+// ——— Read the TS source file ———
+const tsSource = readFileSync(tsSourcePath, 'utf8').trim()
 
-// ——— 1) Generate the TS module ———
-const relativeInput = relative(join(__dirname, '..', 'src'), inputPath)
-const tsModule = `// Auto-generated from ${relativeInput}
-// Run \`yarn generate:sampleSpec\` to update
+// ——— Prep snippet version: witch to dicom-curate import and drop comments ———
+const snippetSource = tsSource.replace(
+  /^import type \{ TCurationSpecification \} from ['"][^'"]+['"]\s*;?/m,
+  "import type { TCurationSpecification } from 'dicom-curate';"
+)
 
-export const sampleSpecification = \`${content}\`
-`
-writeFileSync(outputTsPath, tsModule, 'utf8')
-console.log(`✅ Generated ${outputTsPath}`)
+// ——— 1) Generate the JS module via transpilation ———
+const jsOutput = ts.transpileModule(tsSource, {
+  compilerOptions: {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    removeComments: false,
+    alwaysStrict: false,
+  },
+}).outputText
+
+writeFileSync(jsOutPath, jsOutput, 'utf8')
+console.log(`✅ Generated ${jsOutPath}`)
 
 // ——— 2) Sync only the *annotated* README snippet ———
 const readme = readFileSync(readmePath, 'utf8')
+const relativeInput = relative(join(__dirname, '..'), tsSourcePath)
 const MARKER = `<!-- Snippet auto-generated from ${relativeInput} -->`
 
 // — extract the first array under "// File path"
 const filePathRe = /^[ \t]*\/\/ File path\s*\r?\n[ \t]*(\[[\s\S]*?\]),?/m
-const filePathMatch = content.match(filePathRe)
-
-if (!filePathMatch) {
-  console.warn(
-    `⚠️  No "// File path" comment found in ${inputPath}, retaining existing errors block`,
-  )
-}
+const filePathMatch = snippetSource.match(filePathRe)
 const filePathItem = filePathMatch ? filePathMatch[1].trim() : ''
 
 // — extract the first array under "// DICOM header"
 const dicomRe = /^[ \t]*\/\/ DICOM header\s*\r?\n[ \t]*(\[[\s\S]*?\]),?/m
-const dicomMatch = content.match(dicomRe)
-
-if (filePathMatch && !dicomMatch) {
-  console.warn(
-    `⚠️  No "// DICOM header" comment found in ${inputPath}, retaining existing errors block`,
-  )
-}
+const dicomMatch = snippetSource.match(dicomRe)
 const dicomItem = dicomMatch ? dicomMatch[1].trim() : ''
 
-// — capture the indent of the `errors:` line *and* match the entire existing block
+// — capture the indent of the errors: line *and* match the entire existing block
 const errorsRe = new RegExp(
   '^([ \\t]*)errors\\s*:\\s*\\[[ \\t]*\\r?\\n[\\s\\S]*?^\\1\\],?',
   'm',
 )
-const errorsMatch = content.match(errorsRe)
-if (filePathMatch && dicomMatch && !errorsMatch) {
-  console.warn(
-    `⚠️  No "errors: [...]" block found in ${inputPath}, skipping errors replacement`,
-  )
-}
+const errorsMatch = snippetSource.match(errorsRe)
 const indent = errorsMatch ? errorsMatch[1] : '  '
 
 // — build a new errors: [ … ] block
@@ -89,27 +83,27 @@ const newErrorsBlock = (
     : [`${indent}],`]
 ).join('\n')
 
-// — splice it into your script (fall back to original if any regex failed)
-const shortenedContent = newErrorsBlock
-  ? content.replace(errorsRe, newErrorsBlock)
-  : content
+// — splice it into your snippet (fall back to original if any regex failed)
+const shortenedContent = errorsMatch
+  ? snippetSource.replace(errorsRe, newErrorsBlock)
+  : snippetSource
 
-// — wrap that full script in your README snippet
+// — wrap that full script in your README snippet, using TS fences
 const replacement = `${MARKER}
-\`\`\`js
+\`\`\`ts
 ${shortenedContent}
 \`\`\``
 
 // — locate & replace the old fenced snippet
 const escaped = MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-const fenceRe = new RegExp(escaped + '[\\s\\S]*?```js[\\s\\S]*?```', 'm')
+const fenceRe = new RegExp(escaped + '[\\s\\S]*?```ts[\\s\\S]*?```', 'm')
 
 if (fenceRe.test(readme)) {
   const updated = readme.replace(fenceRe, replacement)
   writeFileSync(readmePath, updated, 'utf8')
   console.log(`✅ Updated code snippet in ${readmePath}`)
 } else {
-  console.log(
-    `⚠️  No README snippet marker found ("${MARKER}"), skipping update.`,
+  console.warn(
+    `⚠️ No README snippet marker found ("${MARKER}"), skipping update.`,
   )
 }

--- a/src/@types/acorn-globals.d.ts
+++ b/src/@types/acorn-globals.d.ts
@@ -1,0 +1,13 @@
+declare module 'acorn-globals' {
+  import type { Node } from 'acorn';
+
+  interface GlobalVariable {
+    name: string;
+    nodes: Node[];
+    // You can add more fields here as needed
+  }
+
+  function acornGlobals(ast: Node): GlobalVariable[];
+
+  export = acornGlobals;
+}

--- a/src/checkClosure.ts
+++ b/src/checkClosure.ts
@@ -1,0 +1,66 @@
+// closure-checker.js
+import { parse } from 'acorn'
+import globals from 'acorn-globals'
+
+const DEFAULT_GLOBALS: Set<string> = new Set([
+  'Math',
+  'Date',
+  'JSON',
+  'Array',
+  'Object',
+  'String',
+  'Number',
+  'Boolean',
+  'Symbol',
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'RegExp',
+  'Error',
+])
+
+/*
+ * Analyze a function for:
+ *   - closures (free vars not on globalThis)
+ *   - globalsUsed (identifiers on globalThis but not in DEFAULT_GLOBALS)
+ *
+ * @param {Function} fn
+ * @returns {{ closures: string[], globalsUsed: string[] }}
+ */
+function hasClosure(fn: Function) {
+  const src = `(${fn.toString()})`
+  const ast = parse(src, { ecmaVersion: 'latest', sourceType: 'module' })
+  const allNames = Array.from(new Set(globals(ast).map((g) => g.name)))
+
+  const closures = allNames.filter(
+    (name) => !DEFAULT_GLOBALS.has(name) && !(name in globalThis),
+  )
+
+  const globalsUsed = allNames.filter(
+    (name) => !DEFAULT_GLOBALS.has(name) && name in globalThis,
+  )
+
+  return { closures, globalsUsed }
+}
+
+/*
+ * Throws on either:
+ *   - forbidden globalThis use
+ *   - any true closures
+ *
+ * @param {Function} fn
+ * @throws {Error}
+ */
+export function assertNoClosure(fn: Function) {
+  const { closures, globalsUsed } = hasClosure(fn)
+
+  if (globalsUsed.length) {
+    throw new Error(`Forbidden globals usage: ${globalsUsed.join(', ')}`)
+  }
+  if (closures.length) {
+    throw new Error(
+      `Function cannot be serialized due to closed-over variables: ${closures.join(', ')}`,
+    )
+  }
+}

--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -48,8 +48,8 @@ export default function collectMappings(
     validation: () => ({ errors: [] }),
   }
 
-  // TODO: try/except with useful error hinting at curationSpec
-  eval(mappingOptions.curationSpec)
+  // This is a save eval because the api receives a real function.
+  eval(`curationSpecification = ${mappingOptions.curationSpecStr}`)
 
   const spec = curationSpecification()
 

--- a/src/config/sample2PassCurationSpecification.ts
+++ b/src/config/sample2PassCurationSpecification.ts
@@ -1,0 +1,74 @@
+import { sampleBatchCurationSpecification } from './sampleBatchCurationSpecification'
+import type { TCurationSpecification } from '../types'
+
+/*
+ * Sample of a 2-pass curation specification.
+ * First pass: collect the mapping input from the listing
+ * Second pass: load the mapping output from the CSV file
+ */
+export function sample2PassCurationSpecification(): TCurationSpecification {
+  const batchSpec = sampleBatchCurationSpecification()
+  const identifiers = batchSpec.identifiers
+  return {
+    ...batchSpec,
+    additionalData: {
+      // type listing is to collect the mapping input in a first pass.
+      type: 'listing',
+      // function if firstPass
+      collect: (parser) => {
+        const lookups = {
+          PatNamePatId: ['PatientName', 'PatientID']
+            .map(parser.getDicom)
+            .join('='),
+          PatNameSeriesDesc: ['PatientName', 'PatientID', 'SeriesDescription']
+            .map(parser.getDicom)
+            .join('='),
+        }
+        return {
+          lookups,
+          info: [
+            // [label, value]
+            ['Patient Name', parser.getDicom('PatientName')],
+            ['Patient ID', parser.getDicom('PatientID')],
+            ['Study Date', parser.getDicom('StudyDate')],
+            ['Study Description', parser.getDicom('StudyDescription')],
+            ['Series Date', parser.getDicom('SeriesDate')],
+            ['Series Description', parser.getDicom('SeriesDescription')],
+            ['Modality', parser.getDicom('Modality')],
+          ],
+          // This will imply a CSV with headers:
+          // PatNamePatId | PatNameSeriesDesc | CenterSubjectId | Timepoint | Comment
+          // [lookup header, format, lookup value]
+          collect: [
+            ['CenterSubjectId', identifiers.centerSubjectId, 'PatNamePatId'],
+            ['Timepoint', identifiers.timepointNames, 'PatNameSeriesDesc'],
+            ['Comment', /.*/, 'PatNameSeriesDesc'],
+          ],
+        }
+      },
+      // type: 'load',
+      // collect: {
+      //   CURR_ID: identifiers.centerSubjectId,
+      //   StudyDescription: identifiers.timepointNames,
+      //   MAPPED_ID: /BLIND_\d+/,
+      // },
+      // With this, can refer to mappings as parser.getMapping('blindedId')
+      mapping: {
+        // csv situation
+        blindedId: {
+          value: (parser) => parser.getDicom('PatientID'),
+          lookup: (row) => row['CURR_ID'],
+          replace: (row) => row['MAPPED_ID'],
+        },
+        // firstPass situation
+        centerSubjectId: {
+          value: (parser) =>
+            ['PatientName', 'PatientID'].map(parser.getDicom).join('='),
+          // TODO: could rely on lookup and not need the combined field or field name
+          lookup: (row) => row['PatNamePatId'],
+          replace: (row) => row['CenterSubjectId'],
+        },
+      },
+    },
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,9 @@ export type TPs315Options = {
   retainInstitutionIdentityOption: boolean
 }
 
-
-
 export type OrganizeOptions = {
   outputDirectory: FileSystemDirectoryHandle
-  curationSpec: string
+  curationSpec: () => TCurationSpecification
   table?: Row[]
   skipWrite?: boolean
 } & (
@@ -36,7 +34,8 @@ export type OrganizeOptions = {
 
 export type TMappingOptions = {
   columnMappings?: TColumnMappings
-  curationSpec: string
+  // string for passing to workers
+  curationSpecStr: string
   skipWrite?: boolean
 }
 
@@ -104,13 +103,13 @@ export type TParser = {
 type TMappingInputDirect = {
   // load: csv file
   type: 'load'
-  collect: Record<string, RegExp>
+  collect: Record<string, RegExp | string[]>
 }
 
 type TMappingTwoPassInfo = [name: string, value: string]
 type TMappingTwoPassCollect = [
   value: string,
-  format: RegExp,
+  format: RegExp | string[],
   lookupField: string,
 ]
 

--- a/testdata/sampleCurationSpecification.js
+++ b/testdata/sampleCurationSpecification.js
@@ -1,234 +1,182 @@
-curationSpecification = () => {
-  // Confirm allowed identifiers for this transfer.
-  const identifiers = {
-    protocolNumber: 'Sample_Protocol_Number',
-    activityProviderName: 'Sample_CRO',
-    centerSubjectId: /^[A-Z]{3}\d{2}-\d{4}$/,
-    timepointNames: ['Visit 1', 'Visit 2', 'Visit 3'],
-    // Folder "scan": the trial-specific/provider-assigned series name
-    scanNames: ['3DT1 Sagittal', 'PET-Abdomen'],
-  }
-
-  return {
-    // Review the required input folder structure (all DICOM files need minimally this folder depth)
-    // This configuration depends on correct centerSubjectId, timepoint, scan folder names.
-    inputPathPattern:
-      'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
-
-    // collect from both csv and listing
-    additionalData: {
-      type: 'listing',
-      // function if firstPass
-      collect: (parser) => {
-        const lookups = {
-          PatNamePatId: ['PatientName', 'PatientID']
-            .map(parser.getDicom)
-            .join('='),
-          PatNameSeriesDesc: ['PatientName', 'PatientID', 'SeriesDescription']
-            .map(parser.getDicom)
-            .join('='),
-        }
-        return {
-          lookups,
-          info: [
-            // [label, value]
-            ['Patient Name', parser.getDicom('PatientName')],
-            ['Patient ID', parser.getDicom('PatientID')],
-            ['Study Date', parser.getDicom('StudyDate')],
-            ['Study Description', parser.getDicom('StudyDescription')],
-            ['Series Date', parser.getDicom('SeriesDate')],
-            ['Series Description', parser.getDicom('SeriesDescription')],
-            ['Modality', parser.getDicom('Modality')],
-          ],
-          // This will imply a CSV with headers:
-          // PatNamePatId | PatNameSeriesDesc | CenterSubjectId | Timepoint | Comment
-          // [lookup header, format, lookup value]
-          collect: [
-            ['CenterSubjectId', identifiers.centerSubjectId, 'PatNamePatId'],
-            ['Timepoint', identifiers.timepointNames, 'PatNameSeriesDesc'],
-            ['Comment', /.*/, 'PatNameSeriesDesc'],
-          ],
-        }
-      },
-      // type: 'load',
-      // collect: {
-      //   CURR_ID: identifiers.centerSubjectId,
-      //   StudyDescription: identifiers.timepointNames,
-      //   MAPPED_ID: /BLIND_\d+/,
-      // },
-      // With this, can refer to mappings as parser.getMapping('blindedId')
-      mapping: {
-        // csv situation
-        blindedId: {
-          value: (parser) => parser.getDicom('PatientID'),
-          lookup: (row) => row['CURR_ID'],
-          replace: (row) => row['MAPPED_ID'],
+/*
+ * Curation specification for batch-curating DICOM files.
+ */
+export function sampleBatchCurationSpecification() {
+    // Confirm allowed identifiers for this transfer.
+    const identifiers = {
+        protocolNumber: 'Sample_Protocol_Number',
+        activityProviderName: 'Sample_CRO',
+        centerSubjectId: /^[A-Z]{2}\d{2}-\d{3}$/,
+        timepointNames: ['Visit 1', 'Visit 2', 'Visit 3'],
+        // Folder "scan": the trial-specific/provider-assigned series name
+        scanNames: ['3DT1 Sagittal', 'PET-Abdomen'],
+    };
+    return {
+        // Review the required input folder structure (all DICOM files need minimally this folder depth)
+        // This configuration depends on correct centerSubjectId, timepoint, scan folder names.
+        inputPathPattern: 'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+        additionalData: {
+            // collect from a csv file. A client can use regex to validate the input.
+            type: 'load',
+            collect: {
+                CURR_ID: identifiers.centerSubjectId,
+                StudyDescription: identifiers.timepointNames,
+                MAPPED_ID: /BLIND_\d+/,
+            },
+            // With this, can refer to mappings as parser.getMapping('blindedId')
+            mapping: {
+                // Using the CSV
+                blindedId: {
+                    value: (parser) => parser.getDicom('PatientID'),
+                    lookup: (row) => row['CURR_ID'],
+                    replace: (row) => row['MAPPED_ID'],
+                },
+            },
         },
-        // firstPass situation
-        centerSubjectId: {
-          value: (parser) =>
-            ['PatientName', 'PatientID'].map(parser.getDicom).join('='),
-          // TODO: could rely on lookup and not need the combined field or field name
-          lookup: (row) => row['PatNamePatId'],
-          replace: (row) => row['CenterSubjectId'],
+        version: '1.1',
+        identifiers,
+        // This specifies the standardized DICOM de-identification
+        dicomPS315EOptions: {
+            cleanDescriptorsOption: true,
+            cleanDescriptorsExceptions: ['SeriesDescription'],
+            retainLongitudinalTemporalInformationOptions: 'Full',
+            retainPatientCharacteristicsOption: [
+                'PatientsWeight',
+                'PatientsSize',
+                'PatientsAge',
+                'PatientsSex',
+                'SelectorASValue',
+            ],
+            retainDeviceIdentityOption: true,
+            retainUIDsOption: 'Hashed',
+            retainSafePrivateOption: 'Quarantine',
+            retainInstitutionIdentityOption: true,
         },
-      },
-    },
-
-    version: '1.1',
-    identifiers,
-
-    // This specifies the standardized DICOM de-identification
-    dicomPS315EOptions: {
-      cleanDescriptorsOption: true,
-      cleanDescriptorsExceptions: ['SeriesDescription'],
-      retainLongitudinalTemporalInformationOptions: 'Full',
-      retainPatientCharacteristicsOption: [
-        'PatientsWeight',
-        'PatientsSize',
-        'PatientsAge',
-        'PatientsSex',
-        'SelectorASValue',
-      ],
-      retainDeviceIdentityOption: true,
-      retainUIDsOption: 'Hashed',
-      retainSafePrivateOption: 'Quarantine',
-      retainInstitutionIdentityOption: true,
-    },
-
-    // This section defines the output folder structure and alignment of DICOM headers
-    modifications(parser) {
-      const scan = parser.getFilePathComp('scan')
-      const centerSubjectId = parser.getFilePathComp('centerSubjectId')
-
-      return {
-        dicomHeader: {
-          // Align the PatientID DICOM header with the centerSubjectId folder name.
-          PatientID: centerSubjectId,
-          // This example maps PatientIDs based on the mapping CSV file.
-          // PatientID: parser.getMapping('blindedId'),
-          PatientName: centerSubjectId,
-          // Align the StudyDescription DICOM header with the timepoint folder name.
-          StudyDescription: parser.getFilePathComp('timepoint'),
-          // The party responsible for assigning a standard ClinicalTrialSeriesDescription
-          ClinicalTrialCoordinatingCenterName: identifiers.activityProviderName,
-          // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
-          ClinicalTrialSeriesDescription: scan,
+        // This section defines the output folder structure and alignment of DICOM headers
+        modifications(parser) {
+            const scan = parser.getFilePathComp('scan');
+            const centerSubjectId = parser.getFilePathComp('centerSubjectId');
+            return {
+                dicomHeader: {
+                    // Align the PatientID DICOM header with the centerSubjectId folder name.
+                    PatientID: centerSubjectId,
+                    // This example maps PatientIDs based on the mapping CSV file.
+                    // PatientID: parser.getMapping('blindedId'),
+                    PatientName: centerSubjectId,
+                    // Align the StudyDescription DICOM header with the timepoint folder name.
+                    StudyDescription: parser.getFilePathComp('timepoint'),
+                    // The party responsible for assigning a standard ClinicalTrialSeriesDescription
+                    ClinicalTrialCoordinatingCenterName: identifiers.activityProviderName,
+                    // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
+                    ClinicalTrialSeriesDescription: scan,
+                },
+                // This defines the output folder structure.
+                outputFilePathComponents: [
+                    parser.getFilePathComp('protocolNumber'),
+                    parser.getFilePathComp('activityProvider'),
+                    centerSubjectId,
+                    parser.getFilePathComp('timepoint'),
+                    parser.getFilePathComp('scan') +
+                        '=' +
+                        parser.getDicom('SeriesNumber'),
+                    parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
+                ],
+            };
         },
-
-        // This defines the output folder structure.
-        outputFilePathComponents: [
-          parser.getFilePathComp('protocolNumber'),
-          parser.getFilePathComp('activityProvider'),
-          centerSubjectId,
-          parser.getFilePathComp('timepoint'),
-          parser.getFilePathComp('scan') +
-            '=' +
-            parser.getDicom('SeriesNumber'),
-          parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
-        ],
-      }
-    },
-
-    // This section defines the validation rules for the input DICOMs.
-    // The processing continues on errors, but errors will have to be fixed
-    // or reviewed between the parties.
-    validation(parser) {
-      const modality = parser.getDicom('Modality')
-      const filename = parser.getFilePathComp(parser.FILEBASENAME)
-      const seriesUid = parser.getDicom('SeriesInstanceUID')
-
-      return {
-        errors: [
-          // File path
-          [
-            'Invalid study folder name',
-            parser.getFilePathComp('protocolNumber') !==
-              identifiers.protocolNumber,
-          ],
-          [
-            'Invalid provider name',
-            parser.getFilePathComp('activityProvider') !==
-              identifiers.activityProviderName,
-          ],
-          [
-            'Invalid site-subject format',
-            !parser
-              .getFilePathComp('centerSubjectId')
-              .match(identifiers.centerSubjectIdPattern),
-          ],
-          [
-            'Invalid timepoint descriptor',
-            !identifiers.timepointNames.includes(
-              parser.getFilePathComp('timepoint'),
-            ),
-          ],
-          [
-            'Invalid scan descriptor',
-            !identifiers.scanNames.includes(parser.getFilePathComp('scan')),
-          ],
-          // DICOM header
-          ['Missing Modality', parser.missingDicom('Modality')],
-          ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
-          ['Missing Instance Number(s)', parser.missingDicom('InstanceNumber')],
-          [
-            'Duplicate File Name(s) in series',
-            !parser.isUniqueInGroup(filename, seriesUid),
-          ],
-          [
-            'Missing Series Instance UID',
-            parser.missingDicom('SeriesInstanceUID'),
-          ],
-          [
-            'Missing Study Instance UID',
-            parser.missingDicom('StudyInstanceUID'),
-          ],
-          ['Missing SOP Instance UID', parser.missingDicom('SOPInstanceUID')],
-          ['Missing Study Date', parser.missingDicom('StudyDate')],
-          ['Missing Series Date', parser.missingDicom('SeriesDate')],
-          ['Missing Acquisition Date', parser.missingDicom('AcquisitionDate')],
-          ['Missing Study Time', parser.missingDicom('StudyTime')],
-          ['Missing Series Time', parser.missingDicom('SeriesTime')],
-          ['Missing Patient Weight', parser.missingDicom('PatientWeight')],
-          ['Missing Patient Size', parser.missingDicom('PatientSize')],
-          ['Missing Patient Age', parser.missingDicom('PatientAge')],
-          ['Missing Patient Sex', parser.missingDicom('PatientSex')],
-          ['Missing Acquisition Time', parser.missingDicom('AcquisitionTime')],
-          [
-            'Missing Image Position (Patient)',
-            parser.missingDicom('ImagePositionPatient'),
-          ],
-          [
-            'Missing Number of Energy Windows on NM',
-            parser.missingDicom('NumberOfEnergyWindows') && modality === 'NM',
-          ],
-          [
-            'Missing Energy Window Information Sequence on NM',
-            parser.missingDicom('EnergyWindowInformationSequence') &&
-              modality === 'NM',
-          ],
-          [
-            'Missing Energy Window Range Sequence on NM',
-            parser.missingDicom(
-              'EnergyWindowInformationSequence[0].EnergyWindowRangeSequence',
-            ) && modality === 'NM',
-          ],
-          [
-            'Missing Radiopharmaceutical Information Sequence on NM',
-            parser.missingDicom('RadiopharmaceuticalInformationSequence') &&
-              modality === 'NM',
-          ],
-          [
-            'Missing Series Type on PET',
-            parser.missingDicom('SeriesType') && modality === 'PT',
-          ],
-          [
-            'Missing Pixel Spacing on NM or PT or CT',
-            parser.missingDicom('PixelSpacing') &&
-              ['NM', 'PT', 'CT'].includes(modality),
-          ],
-        ],
-      }
-    },
-  }
+        // This section defines the validation rules for the input DICOMs.
+        // The processing continues on errors, but errors will have to be fixed
+        // or reviewed between the parties.
+        validation(parser) {
+            const modality = parser.getDicom('Modality');
+            const filename = parser.getFilePathComp(parser.FILEBASENAME);
+            const seriesUid = parser.getDicom('SeriesInstanceUID');
+            return {
+                errors: [
+                    // File path
+                    [
+                        'Invalid study folder name',
+                        parser.getFilePathComp('protocolNumber') !==
+                            identifiers.protocolNumber,
+                    ],
+                    [
+                        'Invalid provider name',
+                        parser.getFilePathComp('activityProvider') !==
+                            identifiers.activityProviderName,
+                    ],
+                    [
+                        'Invalid site-subject format',
+                        !parser
+                            .getFilePathComp('centerSubjectId')
+                            .match(identifiers.centerSubjectId),
+                    ],
+                    [
+                        'Invalid timepoint descriptor',
+                        !identifiers.timepointNames.includes(parser.getFilePathComp('timepoint')),
+                    ],
+                    [
+                        'Invalid scan descriptor',
+                        !identifiers.scanNames.includes(parser.getFilePathComp('scan')),
+                    ],
+                    // DICOM header
+                    ['Missing Modality', parser.missingDicom('Modality')],
+                    ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
+                    ['Missing Instance Number(s)', parser.missingDicom('InstanceNumber')],
+                    [
+                        'Duplicate File Name(s) in series',
+                        !parser.isUniqueInGroup(filename, seriesUid),
+                    ],
+                    [
+                        'Missing Series Instance UID',
+                        parser.missingDicom('SeriesInstanceUID'),
+                    ],
+                    [
+                        'Missing Study Instance UID',
+                        parser.missingDicom('StudyInstanceUID'),
+                    ],
+                    ['Missing SOP Instance UID', parser.missingDicom('SOPInstanceUID')],
+                    ['Missing Study Date', parser.missingDicom('StudyDate')],
+                    ['Missing Series Date', parser.missingDicom('SeriesDate')],
+                    ['Missing Acquisition Date', parser.missingDicom('AcquisitionDate')],
+                    ['Missing Study Time', parser.missingDicom('StudyTime')],
+                    ['Missing Series Time', parser.missingDicom('SeriesTime')],
+                    ['Missing Patient Weight', parser.missingDicom('PatientWeight')],
+                    ['Missing Patient Size', parser.missingDicom('PatientSize')],
+                    ['Missing Patient Age', parser.missingDicom('PatientAge')],
+                    ['Missing Patient Sex', parser.missingDicom('PatientSex')],
+                    ['Missing Acquisition Time', parser.missingDicom('AcquisitionTime')],
+                    [
+                        'Missing Image Position (Patient)',
+                        parser.missingDicom('ImagePositionPatient'),
+                    ],
+                    [
+                        'Missing Number of Energy Windows on NM',
+                        parser.missingDicom('NumberOfEnergyWindows') && modality === 'NM',
+                    ],
+                    [
+                        'Missing Energy Window Information Sequence on NM',
+                        parser.missingDicom('EnergyWindowInformationSequence') &&
+                            modality === 'NM',
+                    ],
+                    [
+                        'Missing Energy Window Range Sequence on NM',
+                        parser.missingDicom('EnergyWindowInformationSequence[0].EnergyWindowRangeSequence') && modality === 'NM',
+                    ],
+                    [
+                        'Missing Radiopharmaceutical Information Sequence on NM',
+                        parser.missingDicom('RadiopharmaceuticalInformationSequence') &&
+                            modality === 'NM',
+                    ],
+                    [
+                        'Missing Series Type on PET',
+                        parser.missingDicom('SeriesType') && modality === 'PT',
+                    ],
+                    [
+                        'Missing Pixel Spacing on NM or PT or CT',
+                        parser.missingDicom('PixelSpacing') &&
+                            ['NM', 'PT', 'CT'].includes(modality),
+                    ],
+                ],
+            };
+        },
+    };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,7 +3049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-globals@npm:^7.0.0":
+"acorn-globals@npm:^7.0.0, acorn-globals@npm:^7.0.1":
   version: 7.0.1
   resolution: "acorn-globals@npm:7.0.1"
   dependencies:
@@ -3083,6 +3083,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10/6df29c35556782ca9e632db461a7f97947772c6c1d5438a81f0c873a3da3a792487e83e404d1c6c25f70513e91aa18745f6eafb1fcc3a43ecd1920b21dd173d2
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.14.1":
+  version: 8.14.1
+  resolution: "acorn@npm:8.14.1"
+  bin:
+    acorn: bin/acorn
+  checksum: 10/d1379bbee224e8d44c3c3946e6ba6973e999fbdd4e22e41c3455d7f9b6f72f7ce18d3dc218002e1e48eea789539cf1cb6d1430c81838c6744799c712fb557d92
   languageName: node
   linkType: hard
 
@@ -4385,6 +4394,8 @@ __metadata:
   dependencies:
     "@types/lodash": "npm:^4"
     "@types/xml2js": "npm:^0"
+    acorn: "npm:^8.14.1"
+    acorn-globals: "npm:^7.0.1"
     bebbi-scripts: "npm:^0.7.8"
     dcmjs: "npm:^0.38.3"
     husky: "npm:^8.0.3"
@@ -4395,6 +4406,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     prettier: "npm:^3.4.2"
     tsx: "npm:^4.19.3"
+    typescript: "npm:^5.8.3"
     uuid: "npm:^11.0.5"
     xml2js: "npm:^0.6.2"
   languageName: unknown
@@ -10134,6 +10146,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/65c40944c51b513b0172c6710ee62e951b70af6f75d5a5da745cb7fab132c09ae27ffdf7838996e3ed603bb015dadd099006658046941bd0ba30340cc563ae92
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
   version: 5.7.2
   resolution: "typescript@patch:typescript@npm%3A5.7.2#optional!builtin<compat/typescript>::version=5.7.2&hash=5786d5"
@@ -10141,6 +10163,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/d75ca10141afc64fd3474b41a8b082b640555bed388d237558aed64e5827ddadb48f90932c7f4205883f18f5bcab8b6a739a2cfac95855604b0dfeb34bc2f3eb
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
… input.

On apply(), an error is thrown if the function has closures or globals outside the allowlist.

- Re-wire generateSampleSpec ts -> js instead of js -> ts
- Take advantage of modularization to use a different (simpler, batch) sample function in README than the exported sample (which is 2-pass).
- Sample spec has a usage example for mappign
- dcmOrganize.test.ts simplifies the argument, not a string anymore
  - thanks to this it's possible to use template strings in test configs
- a few fixed type errors thanks to the string -> function refactor.

Closes #96