### PR TITLE
feat: simplify TCurationSpecification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "dicom-curate test",
+      "name": "Debug dicom-curate",
       "type": "node",
       "request": "launch",
       "protocol": "inspector",
-      "cwd": "${workspaceFolder}",
-      "env": { "NODE_OPTIONS": "--inspect" },
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["run", "test"],
-      "console": "integratedTerminal",
-      "outputCapture": "std"
+      "runtimeArgs": ["test"],
+      "args": ["--runInBand", "--no-cache"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ import type { TCurationSpecification } from 'dicom-curate'
  * Curation specification for batch-curating DICOM files.
  */
 export function sampleBatchCurationSpecification(): TCurationSpecification {
-  // Confirm hostProps for this transfer.
   const hostProps = {
     protocolNumber: 'Sample_Protocol_Number',
     activityProviderName: 'Sample_CRO',
@@ -141,10 +140,10 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
       cleanDescriptorsExceptions: ['SeriesDescription'],
       retainLongitudinalTemporalInformationOptions: 'Full',
       retainPatientCharacteristicsOption: [
-        'PatientsWeight',
-        'PatientsSize',
-        'PatientsAge',
-        'PatientsSex',
+        'PatientWeight',
+        'PatientSize',
+        'PatientAge',
+        'PatientSex',
         'SelectorASValue',
       ],
       retainDeviceIdentityOption: true,

--- a/scripts/generateSampleSpec.ts
+++ b/scripts/generateSampleSpec.ts
@@ -51,48 +51,11 @@ const readme = readFileSync(readmePath, 'utf8')
 const relativeInput = relative(join(__dirname, '..'), tsSourcePath)
 const MARKER = `<!-- Snippet auto-generated from ${relativeInput} -->`
 
-// — extract the first array under "// File path"
-const filePathRe = /^[ \t]*\/\/ File path\s*\r?\n[ \t]*(\[[\s\S]*?\]),?/m
-const filePathMatch = snippetSource.match(filePathRe)
-const filePathItem = filePathMatch ? filePathMatch[1].trim() : ''
-
-// — extract the first array under "// DICOM header"
-const dicomRe = /^[ \t]*\/\/ DICOM header\s*\r?\n[ \t]*(\[[\s\S]*?\]),?/m
-const dicomMatch = snippetSource.match(dicomRe)
-const dicomItem = dicomMatch ? dicomMatch[1].trim() : ''
-
-// — capture the indent of the errors: line *and* match the entire existing block
-const errorsRe = new RegExp(
-  '^([ \\t]*)errors\\s*:\\s*\\[[ \\t]*\\r?\\n[\\s\\S]*?^\\1\\],?',
-  'm',
-)
-const errorsMatch = snippetSource.match(errorsRe)
-const indent = errorsMatch ? errorsMatch[1] : '  '
-
-// — build a new errors: [ … ] block
-const newErrorsBlock = (
-  filePathMatch && dicomMatch && errorsMatch
-    ? [
-        `${indent}errors: [`,
-        `${indent}  // File path`,
-        `${indent}  ${filePathItem},`,
-        `${indent}  // DICOM header`,
-        `${indent}  ${dicomItem},`,
-        `${indent}],`,
-      ]
-    : [`${indent}],`]
-).join('\n')
-
-// — splice it into your snippet (fall back to original if any regex failed)
-const shortenedContent = errorsMatch
-  ? snippetSource.replace(errorsRe, newErrorsBlock)
-  : snippetSource
-
 // — wrap that full script in your README snippet, using TS fences
 const replacement = `${MARKER}
 
 \`\`\`ts
-${shortenedContent}
+${snippetSource}
 \`\`\``
 
 // — locate & replace the old fenced snippet

--- a/src/config/sample2PassCurationSpecification.ts
+++ b/src/config/sample2PassCurationSpecification.ts
@@ -13,7 +13,6 @@ import type { TCurationSpecification } from '../types'
  * }}
  */
 export function sample2PassCurationSpecification(): TCurationSpecification {
-  // Confirm hostProps for this transfer.
   const hostProps = {
     protocolNumber: 'Sample_Protocol_Number',
     activityProviderName: 'Sample_CRO',
@@ -104,10 +103,10 @@ export function sample2PassCurationSpecification(): TCurationSpecification {
       cleanDescriptorsExceptions: ['SeriesDescription'],
       retainLongitudinalTemporalInformationOptions: 'Full',
       retainPatientCharacteristicsOption: [
-        'PatientsWeight',
-        'PatientsSize',
-        'PatientsAge',
-        'PatientsSex',
+        'PatientWeight',
+        'PatientSize',
+        'PatientAge',
+        'PatientSex',
         'SelectorASValue',
       ],
       retainDeviceIdentityOption: true,

--- a/src/config/sampleBatchCurationSpecification.ts
+++ b/src/config/sampleBatchCurationSpecification.ts
@@ -4,7 +4,6 @@ import type { TCurationSpecification } from '../types'
  * Curation specification for batch-curating DICOM files.
  */
 export function sampleBatchCurationSpecification(): TCurationSpecification {
-  // Confirm hostProps for this transfer.
   const hostProps = {
     protocolNumber: 'Sample_Protocol_Number',
     activityProviderName: 'Sample_CRO',
@@ -48,10 +47,10 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
       cleanDescriptorsExceptions: ['SeriesDescription'],
       retainLongitudinalTemporalInformationOptions: 'Full',
       retainPatientCharacteristicsOption: [
-        'PatientsWeight',
-        'PatientsSize',
-        'PatientsAge',
-        'PatientsSex',
+        'PatientWeight',
+        'PatientSize',
+        'PatientAge',
+        'PatientSex',
         'SelectorASValue',
       ],
       retainDeviceIdentityOption: true,

--- a/src/config/sampleBatchCurationSpecification.ts
+++ b/src/config/sampleBatchCurationSpecification.ts
@@ -4,8 +4,8 @@ import type { TCurationSpecification } from '../types'
  * Curation specification for batch-curating DICOM files.
  */
 export function sampleBatchCurationSpecification(): TCurationSpecification {
-  // Confirm allowed identifiers for this transfer.
-  const identifiers = {
+  // Confirm hostProps for this transfer.
+  const hostProps = {
     protocolNumber: 'Sample_Protocol_Number',
     activityProviderName: 'Sample_CRO',
     centerSubjectId: /^[A-Z]{2}\d{2}-\d{3}$/,
@@ -24,8 +24,8 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
       // collect from a csv file. A client can use regex to validate the input.
       type: 'load',
       collect: {
-        CURR_ID: identifiers.centerSubjectId,
-        StudyDescription: identifiers.timepointNames,
+        CURR_ID: hostProps.centerSubjectId,
+        StudyDescription: hostProps.timepointNames,
         MAPPED_ID: /BLIND_\d+/,
       },
       // With this, can refer to mappings as parser.getMapping('blindedId')
@@ -39,8 +39,8 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
       },
     },
 
-    version: '2.0',
-    identifiers,
+    version: '3.0',
+    hostProps,
 
     // This specifies the standardized DICOM de-identification
     dicomPS315EOptions: {
@@ -60,139 +60,53 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
       retainInstitutionIdentityOption: true,
     },
 
-    // This section defines the output folder structure and alignment of DICOM headers
-    modifications(parser) {
+    modifyDicomHeader(parser) {
       const scan = parser.getFilePathComp('scan')
       const centerSubjectId = parser.getFilePathComp('centerSubjectId')
 
       return {
-        dicomHeader: {
-          // Align the PatientID DICOM header with the centerSubjectId folder name.
-          PatientID: centerSubjectId,
-          // This example maps PatientIDs based on the mapping CSV file.
-          // PatientID: parser.getMapping('blindedId'),
-          PatientName: centerSubjectId,
-          // Align the StudyDescription DICOM header with the timepoint folder name.
-          StudyDescription: parser.getFilePathComp('timepoint'),
-          // The party responsible for assigning a standard ClinicalTrialSeriesDescription
-          ClinicalTrialCoordinatingCenterName: identifiers.activityProviderName,
-          // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
-          ClinicalTrialSeriesDescription: scan,
-        },
-
-        // This defines the output folder structure.
-        outputFilePathComponents: [
-          parser.getFilePathComp('protocolNumber'),
-          parser.getFilePathComp('activityProvider'),
-          centerSubjectId,
-          parser.getFilePathComp('timepoint'),
-          parser.getFilePathComp('scan') +
-            '=' +
-            parser.getDicom('SeriesNumber'),
-          parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
-        ],
+        // Align the PatientID DICOM header with the centerSubjectId folder name.
+        PatientID: centerSubjectId,
+        // This example maps PatientIDs based on the mapping CSV file.
+        // PatientID: parser.getMapping('blindedId'),
+        PatientName: centerSubjectId,
+        // Align the StudyDescription DICOM header with the timepoint folder name.
+        StudyDescription: parser.getFilePathComp('timepoint'),
+        // The party responsible for assigning a standard ClinicalTrialSeriesDescription
+        ClinicalTrialCoordinatingCenterName: hostProps.activityProviderName,
+        // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
+        ClinicalTrialSeriesDescription: scan,
       }
+    },
+
+    outputFilePathComponents(parser) {
+      const scan = parser.getFilePathComp('scan')
+      const centerSubjectId = parser.getFilePathComp('centerSubjectId')
+
+      return [
+        parser.getFilePathComp('protocolNumber'),
+        parser.getFilePathComp('activityProvider'),
+        centerSubjectId,
+        parser.getFilePathComp('timepoint'),
+        scan + '=' + parser.getDicom('SeriesNumber'),
+        parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
+      ]
     },
 
     // This section defines the validation rules for the input DICOMs.
     // The processing continues on errors, but errors will have to be fixed
     // or reviewed between the parties.
-    validation(parser) {
-      const modality = parser.getDicom('Modality')
-      const filename = parser.getFilePathComp(parser.FILEBASENAME)
-      const seriesUid = parser.getDicom('SeriesInstanceUID')
-
-      return {
-        errors: [
-          // File path
-          [
-            'Invalid study folder name',
-            parser.getFilePathComp('protocolNumber') !==
-              identifiers.protocolNumber,
-          ],
-          [
-            'Invalid provider name',
-            parser.getFilePathComp('activityProvider') !==
-              identifiers.activityProviderName,
-          ],
-          [
-            'Invalid site-subject format',
-            !parser
-              .getFilePathComp('centerSubjectId')
-              .match(identifiers.centerSubjectId),
-          ],
-          [
-            'Invalid timepoint descriptor',
-            !identifiers.timepointNames.includes(
-              parser.getFilePathComp('timepoint'),
-            ),
-          ],
-          [
-            'Invalid scan descriptor',
-            !identifiers.scanNames.includes(parser.getFilePathComp('scan')),
-          ],
-          // DICOM header
-          ['Missing Modality', parser.missingDicom('Modality')],
-          ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
-          ['Missing Instance Number(s)', parser.missingDicom('InstanceNumber')],
-          [
-            'Duplicate File Name(s) in series',
-            !parser.isUniqueInGroup(filename, seriesUid),
-          ],
-          [
-            'Missing Series Instance UID',
-            parser.missingDicom('SeriesInstanceUID'),
-          ],
-          [
-            'Missing Study Instance UID',
-            parser.missingDicom('StudyInstanceUID'),
-          ],
-          ['Missing SOP Instance UID', parser.missingDicom('SOPInstanceUID')],
-          ['Missing Study Date', parser.missingDicom('StudyDate')],
-          ['Missing Series Date', parser.missingDicom('SeriesDate')],
-          ['Missing Acquisition Date', parser.missingDicom('AcquisitionDate')],
-          ['Missing Study Time', parser.missingDicom('StudyTime')],
-          ['Missing Series Time', parser.missingDicom('SeriesTime')],
-          ['Missing Patient Weight', parser.missingDicom('PatientWeight')],
-          ['Missing Patient Size', parser.missingDicom('PatientSize')],
-          ['Missing Patient Age', parser.missingDicom('PatientAge')],
-          ['Missing Patient Sex', parser.missingDicom('PatientSex')],
-          ['Missing Acquisition Time', parser.missingDicom('AcquisitionTime')],
-          [
-            'Missing Image Position (Patient)',
-            parser.missingDicom('ImagePositionPatient'),
-          ],
-          [
-            'Missing Number of Energy Windows on NM',
-            parser.missingDicom('NumberOfEnergyWindows') && modality === 'NM',
-          ],
-          [
-            'Missing Energy Window Information Sequence on NM',
-            parser.missingDicom('EnergyWindowInformationSequence') &&
-              modality === 'NM',
-          ],
-          [
-            'Missing Energy Window Range Sequence on NM',
-            parser.missingDicom(
-              'EnergyWindowInformationSequence[0].EnergyWindowRangeSequence',
-            ) && modality === 'NM',
-          ],
-          [
-            'Missing Radiopharmaceutical Information Sequence on NM',
-            parser.missingDicom('RadiopharmaceuticalInformationSequence') &&
-              modality === 'NM',
-          ],
-          [
-            'Missing Series Type on PET',
-            parser.missingDicom('SeriesType') && modality === 'PT',
-          ],
-          [
-            'Missing Pixel Spacing on NM or PT or CT',
-            parser.missingDicom('PixelSpacing') &&
-              ['NM', 'PT', 'CT'].includes(modality),
-          ],
+    errors(parser) {
+      return [
+        // File path
+        [
+          'Invalid study folder name',
+          parser.getFilePathComp('protocolNumber') !== hostProps.protocolNumber,
         ],
-      }
+        // DICOM header
+        ['Missing Modality', parser.missingDicom('Modality')],
+        ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
+      ]
     },
   }
 }

--- a/src/config/specVersion.ts
+++ b/src/config/specVersion.ts
@@ -1,1 +1,1 @@
-export const specVersion = '2.0'
+export const specVersion = '3.0'

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,6 @@ export type {
 export { TCurateOneArgs } from './curateOne'
 
 export { specVersion } from './config/specVersion'
-export { sample2PassCurationSpecification as sampleSpecification } from './config/sample2PassCurationSpecification'
 export { csvTextToRows } from './csvMapping'
 export type { Row } from './csvMapping'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,10 @@ export type TMappingOptions = {
   dateOffset?: Iso8601Duration
 }
 
-export type TSerializedMappingOptions = Omit<TMappingOptions, 'curationSpec'> & {
+export type TSerializedMappingOptions = Omit<
+  TMappingOptions,
+  'curationSpec'
+> & {
   curationSpecStr: string
 }
 
@@ -128,18 +131,19 @@ type TMappingInputTwoPass = {
   }
 }
 
-export type TCurationSpecification = {
+type HPPrimitive = string | number | boolean | null | RegExp
+export type HPValue = HPPrimitive | { [k: string]: HPValue } | HPValue[]
+
+export type HostProps = Record<string, HPValue>
+
+export type TCurationSpecification<THost extends HostProps = HostProps> = {
   version: string
-  modifications: (parser: TParser) => {
-    dicomHeader: { [keyword: string]: string }
-    outputFilePathComponents: string[]
-  }
-  validation: (parser: TParser) => {
-    errors: [message: string, failure: boolean][]
-  }
+  modifyDicomHeader: (parser: TParser) => { [keyword: string]: string }
+  outputFilePathComponents: (parser: TParser) => string[]
+  errors: (parser: TParser) => [message: string, failure: boolean][]
   dicomPS315EOptions: TPs315Options | 'Off'
   inputPathPattern: string
-  identifiers: Record<string, any>
+  hostProps: THost
   additionalData?: { mapping: TMappedValues } & (
     | TMappingInputDirect
     | TMappingInputTwoPass

--- a/testdata/sampleCurationSpecification.js
+++ b/testdata/sampleCurationSpecification.js
@@ -2,181 +2,100 @@
  * Curation specification for batch-curating DICOM files.
  */
 export function sampleBatchCurationSpecification() {
-    // Confirm allowed identifiers for this transfer.
-    const identifiers = {
-        protocolNumber: 'Sample_Protocol_Number',
-        activityProviderName: 'Sample_CRO',
-        centerSubjectId: /^[A-Z]{2}\d{2}-\d{3}$/,
-        timepointNames: ['Visit 1', 'Visit 2', 'Visit 3'],
-        // Folder "scan": the trial-specific/provider-assigned series name
-        scanNames: ['3DT1 Sagittal', 'PET-Abdomen'],
-    };
-    return {
-        // Review the required input folder structure (all DICOM files need minimally this folder depth)
-        // This configuration depends on correct centerSubjectId, timepoint, scan folder names.
-        inputPathPattern: 'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
-        additionalData: {
-            // collect from a csv file. A client can use regex to validate the input.
-            type: 'load',
-            collect: {
-                CURR_ID: identifiers.centerSubjectId,
-                StudyDescription: identifiers.timepointNames,
-                MAPPED_ID: /BLIND_\d+/,
-            },
-            // With this, can refer to mappings as parser.getMapping('blindedId')
-            mapping: {
-                // Using the CSV
-                blindedId: {
-                    value: (parser) => parser.getDicom('PatientID'),
-                    lookup: (row) => row['CURR_ID'],
-                    replace: (row) => row['MAPPED_ID'],
-                },
-            },
+  // Confirm hostProps for this transfer.
+  const hostProps = {
+    protocolNumber: 'Sample_Protocol_Number',
+    activityProviderName: 'Sample_CRO',
+    centerSubjectId: /^[A-Z]{2}\d{2}-\d{3}$/,
+    timepointNames: ['Visit 1', 'Visit 2', 'Visit 3'],
+    // Folder "scan": the trial-specific/provider-assigned series name
+    scanNames: ['3DT1 Sagittal', 'PET-Abdomen'],
+  }
+  return {
+    // Review the required input folder structure (all DICOM files need minimally this folder depth)
+    // This configuration depends on correct centerSubjectId, timepoint, scan folder names.
+    inputPathPattern:
+      'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+    additionalData: {
+      // collect from a csv file. A client can use regex to validate the input.
+      type: 'load',
+      collect: {
+        CURR_ID: hostProps.centerSubjectId,
+        StudyDescription: hostProps.timepointNames,
+        MAPPED_ID: /BLIND_\d+/,
+      },
+      // With this, can refer to mappings as parser.getMapping('blindedId')
+      mapping: {
+        // Using the CSV
+        blindedId: {
+          value: (parser) => parser.getDicom('PatientID'),
+          lookup: (row) => row['CURR_ID'],
+          replace: (row) => row['MAPPED_ID'],
         },
-        version: '2.0',
-        identifiers,
-        // This specifies the standardized DICOM de-identification
-        dicomPS315EOptions: {
-            cleanDescriptorsOption: true,
-            cleanDescriptorsExceptions: ['SeriesDescription'],
-            retainLongitudinalTemporalInformationOptions: 'Full',
-            retainPatientCharacteristicsOption: [
-                'PatientsWeight',
-                'PatientsSize',
-                'PatientsAge',
-                'PatientsSex',
-                'SelectorASValue',
-            ],
-            retainDeviceIdentityOption: true,
-            retainUIDsOption: 'Hashed',
-            retainSafePrivateOption: 'Quarantine',
-            retainInstitutionIdentityOption: true,
-        },
-        // This section defines the output folder structure and alignment of DICOM headers
-        modifications(parser) {
-            const scan = parser.getFilePathComp('scan');
-            const centerSubjectId = parser.getFilePathComp('centerSubjectId');
-            return {
-                dicomHeader: {
-                    // Align the PatientID DICOM header with the centerSubjectId folder name.
-                    PatientID: centerSubjectId,
-                    // This example maps PatientIDs based on the mapping CSV file.
-                    // PatientID: parser.getMapping('blindedId'),
-                    PatientName: centerSubjectId,
-                    // Align the StudyDescription DICOM header with the timepoint folder name.
-                    StudyDescription: parser.getFilePathComp('timepoint'),
-                    // The party responsible for assigning a standard ClinicalTrialSeriesDescription
-                    ClinicalTrialCoordinatingCenterName: identifiers.activityProviderName,
-                    // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
-                    ClinicalTrialSeriesDescription: scan,
-                },
-                // This defines the output folder structure.
-                outputFilePathComponents: [
-                    parser.getFilePathComp('protocolNumber'),
-                    parser.getFilePathComp('activityProvider'),
-                    centerSubjectId,
-                    parser.getFilePathComp('timepoint'),
-                    parser.getFilePathComp('scan') +
-                        '=' +
-                        parser.getDicom('SeriesNumber'),
-                    parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
-                ],
-            };
-        },
-        // This section defines the validation rules for the input DICOMs.
-        // The processing continues on errors, but errors will have to be fixed
-        // or reviewed between the parties.
-        validation(parser) {
-            const modality = parser.getDicom('Modality');
-            const filename = parser.getFilePathComp(parser.FILEBASENAME);
-            const seriesUid = parser.getDicom('SeriesInstanceUID');
-            return {
-                errors: [
-                    // File path
-                    [
-                        'Invalid study folder name',
-                        parser.getFilePathComp('protocolNumber') !==
-                            identifiers.protocolNumber,
-                    ],
-                    [
-                        'Invalid provider name',
-                        parser.getFilePathComp('activityProvider') !==
-                            identifiers.activityProviderName,
-                    ],
-                    [
-                        'Invalid site-subject format',
-                        !parser
-                            .getFilePathComp('centerSubjectId')
-                            .match(identifiers.centerSubjectId),
-                    ],
-                    [
-                        'Invalid timepoint descriptor',
-                        !identifiers.timepointNames.includes(parser.getFilePathComp('timepoint')),
-                    ],
-                    [
-                        'Invalid scan descriptor',
-                        !identifiers.scanNames.includes(parser.getFilePathComp('scan')),
-                    ],
-                    // DICOM header
-                    ['Missing Modality', parser.missingDicom('Modality')],
-                    ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
-                    ['Missing Instance Number(s)', parser.missingDicom('InstanceNumber')],
-                    [
-                        'Duplicate File Name(s) in series',
-                        !parser.isUniqueInGroup(filename, seriesUid),
-                    ],
-                    [
-                        'Missing Series Instance UID',
-                        parser.missingDicom('SeriesInstanceUID'),
-                    ],
-                    [
-                        'Missing Study Instance UID',
-                        parser.missingDicom('StudyInstanceUID'),
-                    ],
-                    ['Missing SOP Instance UID', parser.missingDicom('SOPInstanceUID')],
-                    ['Missing Study Date', parser.missingDicom('StudyDate')],
-                    ['Missing Series Date', parser.missingDicom('SeriesDate')],
-                    ['Missing Acquisition Date', parser.missingDicom('AcquisitionDate')],
-                    ['Missing Study Time', parser.missingDicom('StudyTime')],
-                    ['Missing Series Time', parser.missingDicom('SeriesTime')],
-                    ['Missing Patient Weight', parser.missingDicom('PatientWeight')],
-                    ['Missing Patient Size', parser.missingDicom('PatientSize')],
-                    ['Missing Patient Age', parser.missingDicom('PatientAge')],
-                    ['Missing Patient Sex', parser.missingDicom('PatientSex')],
-                    ['Missing Acquisition Time', parser.missingDicom('AcquisitionTime')],
-                    [
-                        'Missing Image Position (Patient)',
-                        parser.missingDicom('ImagePositionPatient'),
-                    ],
-                    [
-                        'Missing Number of Energy Windows on NM',
-                        parser.missingDicom('NumberOfEnergyWindows') && modality === 'NM',
-                    ],
-                    [
-                        'Missing Energy Window Information Sequence on NM',
-                        parser.missingDicom('EnergyWindowInformationSequence') &&
-                            modality === 'NM',
-                    ],
-                    [
-                        'Missing Energy Window Range Sequence on NM',
-                        parser.missingDicom('EnergyWindowInformationSequence[0].EnergyWindowRangeSequence') && modality === 'NM',
-                    ],
-                    [
-                        'Missing Radiopharmaceutical Information Sequence on NM',
-                        parser.missingDicom('RadiopharmaceuticalInformationSequence') &&
-                            modality === 'NM',
-                    ],
-                    [
-                        'Missing Series Type on PET',
-                        parser.missingDicom('SeriesType') && modality === 'PT',
-                    ],
-                    [
-                        'Missing Pixel Spacing on NM or PT or CT',
-                        parser.missingDicom('PixelSpacing') &&
-                            ['NM', 'PT', 'CT'].includes(modality),
-                    ],
-                ],
-            };
-        },
-    };
+      },
+    },
+    version: '3.0',
+    hostProps,
+    // This specifies the standardized DICOM de-identification
+    dicomPS315EOptions: {
+      cleanDescriptorsOption: true,
+      cleanDescriptorsExceptions: ['SeriesDescription'],
+      retainLongitudinalTemporalInformationOptions: 'Full',
+      retainPatientCharacteristicsOption: [
+        'PatientsWeight',
+        'PatientsSize',
+        'PatientsAge',
+        'PatientsSex',
+        'SelectorASValue',
+      ],
+      retainDeviceIdentityOption: true,
+      retainUIDsOption: 'Hashed',
+      retainSafePrivateOption: 'Quarantine',
+      retainInstitutionIdentityOption: true,
+    },
+    modifyDicomHeader(parser) {
+      const scan = parser.getFilePathComp('scan')
+      const centerSubjectId = parser.getFilePathComp('centerSubjectId')
+      return {
+        // Align the PatientID DICOM header with the centerSubjectId folder name.
+        PatientID: centerSubjectId,
+        // This example maps PatientIDs based on the mapping CSV file.
+        // PatientID: parser.getMapping('blindedId'),
+        PatientName: centerSubjectId,
+        // Align the StudyDescription DICOM header with the timepoint folder name.
+        StudyDescription: parser.getFilePathComp('timepoint'),
+        // The party responsible for assigning a standard ClinicalTrialSeriesDescription
+        ClinicalTrialCoordinatingCenterName: hostProps.activityProviderName,
+        // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
+        ClinicalTrialSeriesDescription: scan,
+      }
+    },
+    outputFilePathComponents(parser) {
+      const scan = parser.getFilePathComp('scan')
+      const centerSubjectId = parser.getFilePathComp('centerSubjectId')
+      return [
+        parser.getFilePathComp('protocolNumber'),
+        parser.getFilePathComp('activityProvider'),
+        centerSubjectId,
+        parser.getFilePathComp('timepoint'),
+        scan + '=' + parser.getDicom('SeriesNumber'),
+        parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
+      ]
+    },
+    // This section defines the validation rules for the input DICOMs.
+    // The processing continues on errors, but errors will have to be fixed
+    // or reviewed between the parties.
+    errors(parser) {
+      return [
+        // File path
+        [
+          'Invalid study folder name',
+          parser.getFilePathComp('protocolNumber') !== hostProps.protocolNumber,
+        ],
+        // DICOM header
+        ['Missing Modality', parser.missingDicom('Modality')],
+        ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
+      ]
+    },
+  }
 }

--- a/testdata/sampleCurationSpecification.js
+++ b/testdata/sampleCurationSpecification.js
@@ -2,7 +2,6 @@
  * Curation specification for batch-curating DICOM files.
  */
 export function sampleBatchCurationSpecification() {
-  // Confirm hostProps for this transfer.
   const hostProps = {
     protocolNumber: 'Sample_Protocol_Number',
     activityProviderName: 'Sample_CRO',
@@ -42,10 +41,10 @@ export function sampleBatchCurationSpecification() {
       cleanDescriptorsExceptions: ['SeriesDescription'],
       retainLongitudinalTemporalInformationOptions: 'Full',
       retainPatientCharacteristicsOption: [
-        'PatientsWeight',
-        'PatientsSize',
-        'PatientsAge',
-        'PatientsSex',
+        'PatientWeight',
+        'PatientSize',
+        'PatientAge',
+        'PatientSex',
         'SelectorASValue',
       ],
       retainDeviceIdentityOption: true,


### PR DESCRIPTION
- Remove nested structures modifications and validation properties
- Replace with flat modifyDicomHeader, outputFilePathComponents, errors props
- Change "identifiers" to "hostProps"
- hostProps is a host-side bag of properties, and can be added as a type parameter
- spec version bumped to 3.0
- simplify the sample batch spec so README generation doesn't need to parse the errors
- Remove parsing errors when populating README, to simplify that script code

Closes #136 