### PR TITLE
Fix/#169 pipeline inconsistencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Type Check
+        run: pnpm tsc --noEmit
+
+      - name: Lint
+        run: pnpm lint
+
       - name: Test
         run: pnpm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm test # optional, but harmless
+      - name: Type Check
+        run: pnpm tsc --noEmit
 
-      - run: pnpm build
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
 
       - name: Release with semantic-release
         run: npx semantic-release


### PR DESCRIPTION
- Add missing lint and type-check steps from CI pipeline
- Split release pipeline into named steps

1. Tested with original failing test file from #166 (forced commit)
<img width="672" height="409" alt="image" src="https://github.com/user-attachments/assets/347ca2d0-9cfa-4489-bd3e-0f8614ddd50a" />

2. Raised PR and check for CI fail ✅ 
<img width="744" height="505" alt="image" src="https://github.com/user-attachments/assets/8e20701d-41fd-45e2-ad54-5d10917ff711" />

3. Reverted failing test file to passing state (no changes in the PR)
