### PR TITLE
fix: mantain transferSyntaxUID to avoid corrupted images

### DIFF
--- a/src/config/dicom/metaheaderTagsToKeep.ts
+++ b/src/config/dicom/metaheaderTagsToKeep.ts
@@ -3,4 +3,5 @@ export const metaheaderTagsToKeep = [
   'ImplementationClassUID',
   'ImplementationVersionName',
   'MediaStorageSOPClassUID',
+  'TransferSyntaxUID',
 ]

--- a/src/mapMetaheader.ts
+++ b/src/mapMetaheader.ts
@@ -17,9 +17,13 @@ export default function mapMetaheader(
       delete naturalMetadata[tag]
     }
   }
-  // add the UID and transfer syntax explicitly
+  // Update the instance UID
   naturalMetadata.MediaStorageSOPInstanceUID = newInstanceUid
-  naturalMetadata.TransferSynxtaxUID = EXPLICIT_LITTLE_ENDIAN // dcmjs always writes this
+  // TransferSyntaxUID is preserved from the original metaheader (included in metaheaderTagsToKeep)
+  // If missing, set a default
+  if (!naturalMetadata.TransferSyntaxUID) {
+    naturalMetadata.TransferSyntaxUID = EXPLICIT_LITTLE_ENDIAN
+  }
   const mappedMetaheader =
     dcmjs.data.DicomMetaDictionary.denaturalizeDataset(naturalMetadata)
   return mappedMetaheader


### PR DESCRIPTION
Closes #189 

Example of testing:

without fix:
<img width="195" height="800" alt="image" src="https://github.com/user-attachments/assets/47487fca-60d0-45a0-9abd-79b993dc8dc6" />

with fix:
<img width="195" height="800" alt="image" src="https://github.com/user-attachments/assets/02bf5be6-c321-426a-b663-1b8eebe46dcb" />
