### PR TITLE
fix: provide correct outputFilePath for skipped files

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,8 @@ type TAttr = { [name: string]: string | TAttr[] }
 
 export type TMapResults = {
   sourceInstanceUID: string
-  outputFilePath: string
+  // may be omitted if no file has been written
+  outputFilePath?: string
   // optional information about the source file (size, name, path, mtime)
   fileInfo?: {
     name: string


### PR DESCRIPTION
* We were providing the input path in outputFilePath if mapping was skipped.
* Improvement - we now provide outputFilePath if we skipped upload based on output path.