### PR TITLE
feat: add support for nested path access in getDicom

### DIFF
--- a/src/getParser.test.ts
+++ b/src/getParser.test.ts
@@ -1,0 +1,42 @@
+import getParser from './getParser'
+
+describe('getParser.getDicom', () => {
+  const naturalData = {
+    Modality: 'NM',
+    PatientID: '12345',
+    EnergyWindowInformationSequence: [
+      {
+        EnergyWindowRangeSequence: [
+          {
+            EnergyWindowLowerLimit: 99,
+            EnergyWindowUpperLimit: 101,
+          },
+        ],
+      },
+    ],
+  }
+
+  const parser = getParser('protocolNumber', 'PN123', naturalData, 'Off')
+
+  it('returns top-level and sequence attributes', () => {
+    expect(parser.getDicom('Modality')).toBe('NM')
+    expect(parser.getDicom('PatientID')).toBe('12345')
+    const seq = parser.getDicom('EnergyWindowInformationSequence')
+    expect(Array.isArray(seq)).toBe(true)
+    expect(seq[0].EnergyWindowRangeSequence[0].EnergyWindowLowerLimit).toBe(99)
+  })
+
+  it('returns correct value for valid nested path', () => {
+    const value = parser.getDicom(
+      'EnergyWindowInformationSequence[0].EnergyWindowRangeSequence[0].EnergyWindowLowerLimit',
+    )
+    expect(value).toBe(99)
+  })
+
+  it('returns undefined for invalid nested path', () => {
+    const value = parser.getDicom(
+      'EnergyWindowInformationSequence[0].EnergyWindowRangeSequence[1].DoesNotExist',
+    )
+    expect(value).toBeUndefined()
+  })
+})

--- a/src/getParser.ts
+++ b/src/getParser.ts
@@ -1,4 +1,5 @@
 import * as dcmjs from 'dcmjs'
+import { get as _get } from 'lodash'
 import { protectUid as rawProtectUid } from './deidentifyPS315E'
 import { getCsvMapping, TColumnMappings } from './csvMapping'
 import type { TNaturalData } from 'dcmjs'
@@ -32,7 +33,8 @@ export default function getParser(
       // if in hex like "(0008,0100)", convert to text key
       attrName = dcmjs.data.DicomMetaDictionary.dictionary[attrName].name
     }
-    return naturalData[attrName]
+    // Use lodash _get to resolve nested DICOM attribute paths
+    return _get(naturalData, attrName)
   }
 
   function getFilePathComp(


### PR DESCRIPTION
Tested via test-driven-development and MedEx using spec bellow.

```
function compositeSpec() {
    return [
      function defaults() {
    // Define a scan name to use if provider cannot provide one.
    function fallbackScanName(parser) {
        const modality = parser.getDicom('Modality') ?? '';
        const imageType = parser.getDicom('ImageType') ?? '';
        const imageTypeStr = Array.isArray(imageType)
            ? imageType.join('_')
            : imageType;
        return `${modality}-${imageTypeStr}`;
    }
    return {
        ctx: { fallbackScanName },
    };
},
      function ps315Default(ctxIn) {
    return {
        spec: {
            version: '3.0',
            dicomPS315EOptions: {
                cleanDescriptorsOption: true,
                cleanDescriptorsExceptions: ['SeriesDescription'],
                retainLongitudinalTemporalInformationOptions: 'Full',
                retainPatientCharacteristicsOption: [
                    'PatientWeight',
                    'PatientSize',
                    'PatientAge',
                    'PatientSex',
                    'SelectorASValue',
                ],
                retainDeviceIdentityOption: true,
                retainUIDsOption: 'Hashed',
                retainSafePrivateOption: 'Quarantine',
                retainInstitutionIdentityOption: true,
            },
        },
    };
},
      function croIngestion(ctxIn) {
    // Where to get reference data for various identifiers.
    function centerSubjectId(parser) {
        return parser.getDicom('PatientID') ?? 'UNKNOWN';
    }
    function timepointName(parser) {
        return parser.getDicom('StudyDescription') ?? 'UNKNOWN';
    }
    function protocolNumber(parser) {
        return parser.getFilePathComp('protocolNumber');
    }
    return {
        ctx: {
            centerSubjectId,
            timepointName,
            protocolNumber,
        },
        spec: {
            version: '3.0',
            inputPathPattern: 'protocolNumber',
        },
    };
},
      function studySettings(ctxIn) {
    const hostProps = {
        protocolNumber: 'sampleProtocol',
        activityProviderName: 'sampleCRO',
        showSpecApproval: true,
        showErrors: true,
        showWarnings: true,
    };
    // Extract visit/timepoint from SeriesDescription
    function timepointName(parser) {
        const seriesDescription = parser.getDicom('SeriesDescription') ?? '';
        const visitId = seriesDescription
            .match(/(?<!\d)\d+(?:\s*-\s*\d+)?\s*(?:MIN|HR)/i)?.[0]
            ?.replace(/\s+/g, '')
            .toUpperCase() || 'UNKNOWN';
        return visitId;
    }
    return {
        ctx: {
            // For information / from the MS Word transfer spec, but not currently enforced.
            // In this study we are auto-creating scan names, not using provider scan names.
            scanName: ctxIn.fallbackScanName,
            // Special convention for sampleProtocol study: standard subject IDs (###-###) or SPECT-NEMA phantoms (###-SPECT-NEMA-<CAMERA_ID>)
            centerSubjectIdPattern: /^(?:\d{3}-\d{3}|\d{3}-SPECT-NEMA-.+)$/,
            // Appends StudyDesc exception as considered safe for this study
            cleanDescriptorsExceptions: ['StudyDescription'],
            // Override sampleCRO default: extract timepoint from SeriesDescription instead of StudyDescription
            timepointName,
            hostProps,
        },
        spec: {
            version: '3.0',
            hostProps,
            errors(parser) {
                return [
                    // Agreed with sampleCRO not to add transmittal form because of investigator names and possible PII in 'comment' field
                    [
                        'Invalid SR modality provided',
                        parser.getDicom('Modality') === 'SR',
                    ],
                ];
            },
        },
    };
},
      function companyStandard(ctxIn) {
    const centerSubjectIdPattern = ctxIn.centerSubjectIdPattern ?? /^[A-Z]{2}\d{2}-\d{3}$/;
    function sanitizePathComponent(value) {
        return value
            .replace(/[^a-zA-Z0-9_\-+ .]/g, '_')
            .replace(/^\.+/, '') // no leading dots
            .replace(/[. ]+$/, '') // no trailing dots/spaces (Windows)
            .replace(/_+/g, '_') // collapse underscores
            .trim();
    }
    return {
        ctx: { centerSubjectIdPattern },
        spec: {
            version: '3.0',
            modifyDicomHeader(parser) {
                const modality = parser.getDicom('Modality') ?? '';
                const imageType = parser.getDicom('ImageType') ?? '';
                const imageTypeStr = Array.isArray(imageType)
                    ? imageType.join('_')
                    : imageType;
                const scan = `${modality}-${imageTypeStr}`;
                // Prefer ctx-provided helpers (trial-specific overrides), fallback to raw DICOM
                const centerSubjectId = ctxIn.centerSubjectId?.(parser) ?? '';
                const timepoint = ctxIn.timepointName?.(parser) ?? '';
                const siteId = centerSubjectId.split('-')[0];
                return {
                    // Align the PatientID DICOM header with the centerSubjectId folder name.
                    ClinicalTrialProtocolID: ctxIn.hostProps.protocolNumber,
                    ClinicalTrialSubjectID: centerSubjectId,
                    ClinicalTrialSubjectReadingID: centerSubjectId,
                    PatientID: centerSubjectId,
                    ClinicalTrialSiteID: siteId,
                    // This example maps PatientIDs based on the mapping CSV file.
                    // PatientID: parser.getMapping('blindedId'),
                    PatientName: centerSubjectId,
                    // Align the StudyDescription DICOM header with the timepoint folder name.
                    StudyDescription: timepoint,
                    ClinicalTrialTimePointID: timepoint,
                    // The party responsible for assigning a standard ClinicalTrialSeriesDescription
                    ClinicalTrialCoordinatingCenterName: ctxIn.hostProps.activityProviderName,
                    // Align the ClinicalTrialSeriesDescription DICOM header with the scan folder name.
                    ClinicalTrialSeriesDescription: scan,
                };
            },
            outputFilePathComponents(parser) {
                const seriesDescription = ctxIn.seriesDescriptionProvided?.(parser) ??
                    (ctxIn.scanName(parser) + '=' + parser.getDicom('SeriesNumber') ||
                        'UNKNOWN');
                return [
                    ctxIn.hostProps.protocolNumber,
                    ctxIn.hostProps.activityProviderName,
                    ctxIn.centerSubjectId(parser),
                    sanitizePathComponent(ctxIn.timepointName(parser)),
                    sanitizePathComponent(seriesDescription),
                    parser.getFilePathComp(parser.FILEBASENAME) + '.dcm',
                ];
            },
            errors(parser) {
                const modality = parser.getDicom('Modality') ?? '';
                const filename = parser.getFilePathComp(parser.FILEBASENAME);
                const seriesUid = parser.getDicom('SeriesInstanceUID') ?? '';
                const centerSubjectId = ctxIn.centerSubjectId(parser);
                const timepoint = ctxIn.timepointName?.(parser) ?? '';
                const timepointNames = ctxIn.hostProps?.timepointNames;
                const imageType = parser.getDicom('ImageType') ?? '';
                const imageTypeStr = Array.isArray(imageType)
                    ? imageType.join('_')
                    : imageType;
                const isPET = modality === 'PT';
                const isDerived = imageTypeStr.includes('DERIVED');
                const qPET = isPET && !isDerived;
                // Use new nested path getDicom access for Energy Window limits
                const energyWindowLower = parser.getDicom('EnergyWindowInformationSequence.0.EnergyWindowRangeSequence.0.EnergyWindowLowerLimit');
                const energyWindowUpper = parser.getDicom('EnergyWindowInformationSequence.0.EnergyWindowRangeSequence.0.EnergyWindowUpperLimit');
                const missingEnergyWindowLimits = typeof energyWindowLower === 'undefined' ||
                    energyWindowLower === '' ||
                    typeof energyWindowUpper === 'undefined' ||
                    energyWindowUpper === '';
                return [
                    [
                        `Invalid protocol number provided, should be '${ctxIn.hostProps.protocolNumber}'`,
                        parser.getFilePathComp('protocolNumber') !==
                            ctxIn.hostProps.protocolNumber,
                    ],
                    [
                        'Invalid DICOM site-subject format',
                        !centerSubjectId.match(centerSubjectIdPattern),
                    ],
                    // Validate timepoint against expected values if defined
                    ...(timepointNames
                        ? [
                            [
                                'Invalid timepoint descriptor',
                                !timepointNames.includes(timepoint),
                            ],
                        ]
                        : []),
                    // DICOM header
                    ['Missing Modality', parser.missingDicom('Modality')],
                    ['Missing SOP Class UID', parser.missingDicom('SOPClassUID')],
                    [
                        'Missing Series Instance UID',
                        parser.missingDicom('SeriesInstanceUID'),
                    ],
                    [
                        'Missing Study Instance UID',
                        parser.missingDicom('StudyInstanceUID'),
                    ],
                    ['Missing SOP Instance UID', parser.missingDicom('SOPInstanceUID')],
                    ['Missing Study Date', parser.missingDicom('StudyDate')],
                    [
                        'Missing Date (AcquisitionDateTime or AcquisitionDate or SeriesDate)',
                        parser.missingDicom('AcquisitionDateTime') &&
                            parser.missingDicom('AcquisitionDate') &&
                            parser.missingDicom('SeriesDate'),
                    ],
                    ['Missing Study Time', parser.missingDicom('StudyTime')],
                    [
                        'Missing Time (AcquisitionDateTime or AcquisitionTime or SeriesTime)',
                        parser.missingDicom('AcquisitionDateTime') &&
                            parser.missingDicom('AcquisitionTime') &&
                            parser.missingDicom('SeriesTime'),
                    ],
                    [
                        'Missing Patient Weight',
                        qPET && parser.missingDicom('PatientWeight'),
                    ],
                    ['Missing Patient Size', qPET && parser.missingDicom('PatientSize')],
                    ['Missing Patient Age', qPET && parser.missingDicom('PatientAge')],
                    ['Missing Patient Sex', qPET && parser.missingDicom('PatientSex')],
                    [
                        'Missing Image Position (Patient)',
                        parser.missingDicom('ImagePositionPatient'),
                    ],
                    [
                        'Missing Number of Energy Windows on NM',
                        parser.missingDicom('NumberOfEnergyWindows') && modality === 'NM',
                    ],
                    [
                        'Missing Energy Window Information Sequence on NM',
                        parser.missingDicom('EnergyWindowInformationSequence') &&
                            modality === 'NM',
                    ],
                    [
                        'Missing Energy Window Limits on NM',
                        missingEnergyWindowLimits && modality === 'NM',
                    ],
                    [
                        'Missing Radiopharmaceutical Information Sequence on NM',
                        parser.missingDicom('RadiopharmaceuticalInformationSequence') &&
                            modality === 'NM',
                    ],
                    [
                        'Missing Series Type on PET',
                        parser.missingDicom('SeriesType') && modality === 'PT',
                    ],
                    [
                        'Missing Pixel Spacing on NM or PT or CT',
                        parser.missingDicom('PixelSpacing') &&
                            ['NM', 'PT', 'CT'].includes(modality),
                    ],
                ];
            },
        },
    };
}
    ];
}
export {};

```