### PR TITLE
fix: correctly concat S3 output prefix when trailing slash is missing

### DIFF
--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -433,7 +433,12 @@ export async function curateOne({
       })
 
       try {
-        const key = outputTarget.s3.prefix + clonedMapResults.outputFilePath!
+        const prefix = outputTarget.s3.prefix
+          ? outputTarget.s3.prefix.endsWith('/')
+            ? outputTarget.s3.prefix
+            : outputTarget.s3.prefix + '/'
+          : ''
+        const key = prefix + clonedMapResults.outputFilePath!
 
         await client.send(
           new s3.PutObjectCommand({


### PR DESCRIPTION
## Summary
- Normalize `outputTarget.s3.prefix` to ensure it ends with `/` before concatenating with the output file path

Closes #219