### PR TITLE
fix: make skipModifications work consistently when skipWrite is false

### DIFF
--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -81,6 +81,10 @@ export default function collectMappings(
     mapResults.outputFilePath = finalSpec
       .outputFilePathComponents(parser)
       .join('/')
+  } else {
+    // When skipping modifications, preserve the input path structure so the
+    // file is written to the output directory with its original relative path.
+    mapResults.outputFilePath = inputFilePath
   }
 
   const rawModality = naturalData.Modality
@@ -92,7 +96,10 @@ export default function collectMappings(
   }
   const modality = modalityStr.trim().replace(/\W/g, '') || 'OT'
 
-  if (finalSpec.dicomPS315EOptions !== 'Off') {
+  if (
+    !mappingOptions.skipModifications &&
+    finalSpec.dicomPS315EOptions !== 'Off'
+  ) {
     deidentifyPS315E({
       naturalData,
       dicomPS315EOptions: finalSpec.dicomPS315EOptions,

--- a/src/curateDict.test.ts
+++ b/src/curateDict.test.ts
@@ -1,3 +1,4 @@
+import * as dcmjs from 'dcmjs'
 import curateDict from './curateDict'
 import { sample } from '../testdata/sample'
 import { writeFileSync, mkdirSync, existsSync } from 'fs'
@@ -1146,5 +1147,32 @@ describe('curateDict basic functionality', () => {
     const mappings = result.mapResults.mappings
     expect('00051100' in mappings).toBe(false)
     expect('GeneralMatchingSequence[0].00510014' in mappings).toBe(false)
+  })
+
+  it('should preserve input path and skip de-identification when skipModifications is true', () => {
+    const inputPath = passingFilename
+    const options: TMappingOptions = {
+      ...defaultTestOptions,
+      skipModifications: true,
+    }
+
+    const sampleData = structuredClone(sample)
+    const result = curateDict(inputPath, sampleData, options)
+
+    // outputFilePath should equal the input path (not empty string)
+    expect(result.mapResults.outputFilePath).toBe(inputPath)
+
+    // No de-identification or spec-driven mappings should be present
+    expect(Object.keys(result.mapResults.mappings)).toHaveLength(0)
+
+    // PatientName should be unchanged (proves de-id didn't run —
+    // defaultTestOptions has dicomPS315EOptions configured, so without
+    // the fix de-id would have mutated the data in-place)
+    const originalPatientName =
+      dcmjs.data.DicomMetaDictionary.naturalizeDataset(sample.dict).PatientName
+    const mappedPatientName = dcmjs.data.DicomMetaDictionary.naturalizeDataset(
+      result.dicomData.dict,
+    ).PatientName
+    expect(mappedPatientName).toEqual(originalPatientName)
   })
 })


### PR DESCRIPTION
## Summary

Closes #225

- Sets `outputFilePath` to the input path when `skipModifications` is true (instead of leaving it as `''`, which would crash or produce garbage on write)
- Gates `deidentifyPS315E` behind `skipModifications` so no DICOM data is mutated when modifications are skipped
- The existing no-op path guard (`outputFilePath === inputFilePath`) naturally skips the filename rewrite, so no additional code needed there
- Adds a test verifying output path, empty mappings, and unchanged PatientName