### PR TITLE
feat: preserve original DICOM bytes when spec produces no header changes

### DIFF
--- a/src/curateOne.test.ts
+++ b/src/curateOne.test.ts
@@ -1,7 +1,11 @@
 import * as dcmjs from 'dcmjs'
 import { jest } from '@jest/globals'
 import { curateOne } from './curateOne'
-import type { TFileInfo, TMappingOptions } from './types'
+import type {
+  TFileInfo,
+  TMappingOptions,
+  TCurationSpecification,
+} from './types'
 
 describe('curateOne with none specification', () => {
   it('returns passthrough mapping results and skips DICOM parsing', async () => {
@@ -56,5 +60,76 @@ describe('curateOne with none specification', () => {
     const mappedBytes = new Uint8Array(await result.mappedBlob!.arrayBuffer())
     expect(Array.from(mappedBytes)).toEqual(Array.from(bytes))
     expect(result.mappingRequired).toBe(false)
+  })
+})
+
+describe('curateOne byte-identical output when no header changes', () => {
+  // A spec that parses the file but makes no DICOM header modifications:
+  // de-identification is Off and modifyDicomHeader returns {}.
+  const noOpSpec: () => TCurationSpecification = () => ({
+    inputPathPattern:
+      'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+    version: '3.0',
+    hostProps: {},
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: (parser) => [
+      parser.getFilePathComp('protocolNumber'),
+      parser.getFilePathComp('activityProvider'),
+      parser.getFilePathComp(parser.FILENAME),
+    ],
+    errors: () => [],
+  })
+
+  const inputPath =
+    'Sample_Protocol_Number/Sample_CRO/AB12-123/Visit 1/PET-Abdomen'
+
+  it('preserves original bytes when spec produces no DICOM header mappings', async () => {
+    // Build a minimal but valid DICOM binary from scratch using dcmjs
+    const dataset = {
+      PatientName: 'Test',
+      PatientID: 'P001',
+      Modality: 'CT',
+      SOPClassUID: '1.2.840.10008.5.1.4.1.1.2',
+      SOPInstanceUID: '1.2.3.4.5.6.7.8.9',
+      SeriesInstanceUID: '1.2.3.4.5.6.7.8',
+      StudyInstanceUID: '1.2.3.4.5.6.7',
+      SeriesNumber: '1',
+    }
+    const dicomDict = new dcmjs.data.DicomDict({
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+      '00020002': { vr: 'UI', Value: [dataset.SOPClassUID] },
+      '00020003': { vr: 'UI', Value: [dataset.SOPInstanceUID] },
+    })
+    dicomDict.dict = dcmjs.data.DicomMetaDictionary.denaturalizeDataset(dataset)
+    const originalBuffer = dicomDict.write({ allowInvalidVRLength: true })
+    const originalBytes = new Uint8Array(originalBuffer)
+
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([originalBuffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: originalBytes.length,
+    }
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: noOpSpec,
+      skipWrite: false,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions,
+    })
+
+    // The output should be byte-identical to the input
+    const mappedBytes = new Uint8Array(await result.mappedBlob!.arrayBuffer())
+    expect(Array.from(mappedBytes)).toEqual(Array.from(originalBytes))
+
+    // Mapping was still evaluated (not skipped like canSkip or 'none')
+    expect(result.mappingRequired).toBe(true)
+    expect(Object.keys(result.mappings!)).toHaveLength(0)
   })
 })

--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -275,6 +275,14 @@ export async function curateOne({
       mappingOptions,
     ))
 
+    // If the spec produced no DICOM header changes, short-circuit to
+    // preserve the original file bytes (the dcmjs round-trip is not byte-preserving).
+    if (Object.keys(clonedMapResults.mappings).length === 0) {
+      mappedDicomData = {
+        write: () => fileArrayBuffer,
+      }
+    }
+
     // Indicate that mapping was required (we didn't hit the early-skip branch above)
     // Previously mappingRequired was only set to false when skipping; ensure it's
     // explicitly set to true when mapping was performed so consumers can rely on


### PR DESCRIPTION
## Summary

Closes #230

- When `mapResults.mappings` is empty after evaluating the curation spec, the original `fileArrayBuffer` is written instead of re-serialized dcmjs output, preserving byte-identical files
- Adds test verifying byte-identical output with `dicomPS315EOptions: 'Off'` and empty `modifyDicomHeader`

The spec is still fully evaluated — output path, errors, listings, and anomalies are all computed normally. Only the final write is short-circuited.