### PR TITLE
fix: add retry with exponential backoff for HTTP uploads

### DIFF
--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -1,6 +1,7 @@
 import * as dcmjs from 'dcmjs'
 import createNestedDirectories from './createNestedDirectories'
 import curateDict from './curateDict'
+import { fetchWithRetry } from './fetchWithRetry'
 import type {
   TFileInfo,
   THashMethod,
@@ -419,7 +420,7 @@ export async function curateOne({
         if (postMappedHashHeader && postMappedHash)
           headers[postMappedHashHeader] = postMappedHash
 
-        const resp = await fetch(uploadUrl, {
+        const resp = await fetchWithRetry(uploadUrl, {
           method: 'PUT',
           headers,
           body: clonedMapResults.mappedBlob,

--- a/src/fetchWithRetry.test.ts
+++ b/src/fetchWithRetry.test.ts
@@ -1,0 +1,135 @@
+import { jest } from '@jest/globals'
+import { fetchWithRetry } from './fetchWithRetry'
+
+describe('fetchWithRetry', () => {
+  let fetchSpy: jest.SpiedFunction<typeof globalThis.fetch>
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async () => new Response('ok', { status: 200 }))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('succeeds on first attempt without retrying', async () => {
+    const resp = await fetchWithRetry('https://example.com', { method: 'PUT' })
+    expect(resp.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on TypeError then succeeds', async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const resultPromise = fetchWithRetry('https://example.com')
+
+    // First attempt fails, backoff 1000ms
+    await jest.advanceTimersByTimeAsync(1000)
+
+    const resp = await resultPromise
+    expect(resp.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries multiple times then succeeds', async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const resultPromise = fetchWithRetry('https://example.com')
+
+    await jest.advanceTimersByTimeAsync(1000) // attempt 1 backoff
+    await jest.advanceTimersByTimeAsync(3000) // attempt 2 backoff
+    await jest.advanceTimersByTimeAsync(9000) // attempt 3 backoff
+
+    const resp = await resultPromise
+    expect(resp.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('exhausts all 5 attempts and throws', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const resultPromise = fetchWithRetry('https://example.com')
+
+    // Attach the rejection handler before advancing timers to avoid
+    // unhandled rejection warnings.
+    const assertion = expect(resultPromise).rejects.toThrow('Failed to fetch')
+
+    // Advance through all 4 backoff delays (attempts 1-4 fail and wait)
+    await jest.advanceTimersByTimeAsync(1000) // after attempt 1
+    await jest.advanceTimersByTimeAsync(3000) // after attempt 2
+    await jest.advanceTimersByTimeAsync(9000) // after attempt 3
+    await jest.advanceTimersByTimeAsync(27000) // after attempt 4
+
+    // Attempt 5 fails and throws
+    await assertion
+    expect(fetchSpy).toHaveBeenCalledTimes(5)
+  })
+
+  it('does not retry on non-TypeError errors', async () => {
+    const error = new DOMException('The operation was aborted', 'AbortError')
+    fetchSpy.mockRejectedValueOnce(error)
+
+    await expect(fetchWithRetry('https://example.com')).rejects.toThrow(
+      'The operation was aborted',
+    )
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry on HTTP error responses', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('Server Error', { status: 500 }),
+    )
+
+    const resp = await fetchWithRetry('https://example.com')
+    expect(resp.status).toBe(500)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies exponential backoff timing', async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const resultPromise = fetchWithRetry('https://example.com')
+
+    // First attempt fails immediately, then waits 1000ms
+    await jest.advanceTimersByTimeAsync(999)
+    expect(fetchSpy).toHaveBeenCalledTimes(1) // still waiting
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2) // second attempt fires
+
+    // Second attempt fails, then waits 3000ms
+    await jest.advanceTimersByTimeAsync(2999)
+    expect(fetchSpy).toHaveBeenCalledTimes(2) // still waiting
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(3) // third attempt fires
+
+    const resp = await resultPromise
+    expect(resp.status).toBe(200)
+  })
+
+  it('passes through request arguments to fetch', async () => {
+    const init = {
+      method: 'PUT' as const,
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: 'test-body',
+    }
+
+    await fetchWithRetry('https://example.com/upload', init)
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/upload', init)
+  })
+})

--- a/src/fetchWithRetry.ts
+++ b/src/fetchWithRetry.ts
@@ -1,0 +1,41 @@
+/**
+ * Wraps fetch() with retry logic for transient network errors.
+ *
+ * Retries only on TypeError (network failure — request never reached the
+ * server). Does NOT retry on HTTP error responses (4xx, 5xx) since those
+ * indicate the request was received and a retry without changing the request
+ * would likely produce the same result.
+ *
+ * Uses exponential backoff (1s, 3s, 9s, 27s, 81s) which also acts as natural
+ * backpressure — workers block during backoff, reducing concurrent uploads.
+ */
+
+const MAX_ATTEMPTS = 5
+const BASE_DELAY_MS = 1000
+const BACKOFF_MULTIPLIER = 3
+
+export async function fetchWithRetry(
+  ...args: Parameters<typeof fetch>
+): Promise<Response> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await fetch(...args)
+    } catch (error) {
+      const isNetworkError = error instanceof TypeError
+      const isLastAttempt = attempt === MAX_ATTEMPTS
+
+      if (!isNetworkError || isLastAttempt) {
+        throw error
+      }
+
+      const delayMs = BASE_DELAY_MS * BACKOFF_MULTIPLIER ** (attempt - 1)
+      console.warn(
+        `fetch attempt ${attempt}/${MAX_ATTEMPTS} failed: ${(error as TypeError).message}. Retrying in ${delayMs}ms...`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+
+  // Unreachable — the loop either returns or throws on the last attempt.
+  throw new Error('fetchWithRetry: unreachable')
+}


### PR DESCRIPTION
## Summary

- Add `fetchWithRetry` wrapper with 5 attempts and exponential backoff (1s, 3s, 9s, 27s, 81s) for HTTP PUT uploads in `curateOne`
- Retry only on `TypeError` (network failure — request never reached server), not on HTTP error responses
- Backoff also acts as natural backpressure — workers block during backoff, reducing concurrent uploads automatically

Closes #233