### PR TITLE
fix: S3 multipart ETag hash compatibility (#237)

### DIFF
--- a/src/applyMappingsWorker.ts
+++ b/src/applyMappingsWorker.ts
@@ -21,6 +21,7 @@ export type MappingRequest =
         preMappedHash?: string
       }
       hashMethod?: THashMethod
+      hashPartSize?: number
       serializedMappingOptions: TSerializedMappingOptions
     }
   | {
@@ -94,6 +95,7 @@ fixupNodeWorkerEnvironment()
                 fileInfo,
                 outputTarget: event.data.outputTarget ?? {},
                 hashMethod: event.data.hashMethod,
+                hashPartSize: event.data.hashPartSize,
                 mappingOptions,
                 previousSourceFileInfo: event.data.previousFileInfo,
                 previousMappedFileInfo: (targetName) => {

--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -17,8 +17,10 @@ export type TCurateOneArgs = {
   outputTarget: TOutputTarget
   mappingOptions: TMappingOptions
   // hash algorithm to use when previousSourceFileInfo is provided. Defaults to 'md5'.
-  // Supported values: 'md5', 'crc64' (NVMe-style / js-crc 64-bit), 'crc32', or 'sha256'.
+  // Supported values: 'md5', 'aws-s3-etag-2025', 'crc64' (NVMe-style), 'crc32', or 'sha256'.
   hashMethod?: THashMethod
+  // Part size (in bytes) for 'aws-s3-etag-2025' hash method. Defaults to 5 MB.
+  hashPartSize?: number
   // If provided, curateOne() will skip processing the file if the passed values
   // match the current properties of the input file.
   previousSourceFileInfo?: {
@@ -43,6 +45,7 @@ export async function curateOne({
   outputTarget,
   mappingOptions,
   hashMethod,
+  hashPartSize,
   previousSourceFileInfo,
   previousMappedFileInfo,
 }: TCurateOneArgs): Promise<
@@ -180,7 +183,11 @@ export async function curateOne({
   if (previousSourceFileInfo?.preMappedHash !== undefined) {
     try {
       // choose hashing algorithm: default to md5 for S3 ETag compatibility
-      preMappedHash = await hash(fileArrayBuffer!, hashMethod ?? 'md5')
+      preMappedHash = await hash(
+        fileArrayBuffer!,
+        hashMethod ?? 'md5',
+        hashPartSize,
+      )
     } catch (e) {
       console.warn(`Failed to compute preMappedHash for ${fileInfo.name}`, e)
     }
@@ -313,7 +320,11 @@ export async function curateOne({
   if (!preMappedHash) {
     try {
       // choose hashing algorithm: default to md5 for S3 ETag compatibility
-      preMappedHash = await hash(fileArrayBuffer!, hashMethod ?? 'md5')
+      preMappedHash = await hash(
+        fileArrayBuffer!,
+        hashMethod ?? 'md5',
+        hashPartSize,
+      )
     } catch (e) {
       console.warn(`Failed to compute preMappedHash for ${fileInfo.name}`, e)
     }
@@ -332,7 +343,11 @@ export async function curateOne({
     })
 
     // Always calculate post-mapped hash even if deep compare is not requested
-    postMappedHash = await hash(modifiedArrayBuffer, hashMethod ?? 'md5')
+    postMappedHash = await hash(
+      modifiedArrayBuffer,
+      hashMethod ?? 'md5',
+      hashPartSize,
+    )
 
     // Release the original file buffer — the modifiedArrayBuffer is all we
     // need from this point. In the passthrough case (no header changes),

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -2,20 +2,25 @@ import { THashMethod } from './types'
 import md5 from 'md5'
 import { createModel } from 'js-crc'
 
+const DEFAULT_HASH_PART_SIZE = 5 * 1024 * 1024 // 5 MB — matches @aws-sdk/lib-storage default
+
 export async function hash(
   buffer: ArrayBuffer,
   hashMethod: THashMethod,
+  hashPartSize?: number,
 ): Promise<string> {
   switch (hashMethod) {
     case 'sha256':
       return await sha256Hex(buffer)
     case 'crc32':
       return crc32Hex(buffer)
+    case 'crc64':
+      return crc64Hex(buffer)
+    case 'aws-s3-etag-2025':
+      return awsS3Etag(buffer, hashPartSize ?? DEFAULT_HASH_PART_SIZE)
     case 'md5':
     default:
       return md5Hex(buffer)
-    case 'crc64':
-      return crc64Hex(buffer)
   }
 }
 
@@ -28,6 +33,53 @@ async function sha256Hex(buffer: ArrayBuffer) {
 
 function md5Hex(buffer: ArrayBuffer) {
   return md5(new Uint8Array(buffer))
+}
+
+/**
+ * Compute a hash that matches the S3 ETag for the given buffer.
+ *
+ * - Single-part (buffer.byteLength <= partSize): plain MD5 hex string.
+ *   This matches the documented S3 ETag behaviour for objects created via
+ *   PUT Object with SSE-S3 (AES256) encryption.
+ *
+ * - Multi-part (buffer.byteLength > partSize): the undocumented but stable
+ *   composite format  md5(concat(md5_raw(part1) … md5_raw(partN)))-N
+ *   that S3 returns for objects created via the Multipart Upload API.
+ */
+function awsS3Etag(buffer: ArrayBuffer, partSize: number): string {
+  if (buffer.byteLength <= partSize) {
+    return md5Hex(buffer)
+  }
+  return multipartMd5(buffer, partSize)
+}
+
+/**
+ * Reproduce the S3 multipart ETag for a buffer given a known part size.
+ *
+ * Algorithm (empirically stable since ~2006, undocumented by AWS):
+ *   1. Split buffer into ceil(size / partSize) chunks
+ *   2. Compute raw MD5 (16 bytes) of each chunk
+ *   3. Concatenate all raw digests
+ *   4. Compute MD5 of the concatenation → hex
+ *   5. Append "-" + number of parts
+ */
+function multipartMd5(buffer: ArrayBuffer, partSize: number): string {
+  const totalSize = buffer.byteLength
+  const partCount = Math.ceil(totalSize / partSize)
+  const rawDigests = new Uint8Array(partCount * 16)
+
+  for (let i = 0; i < partCount; i++) {
+    const start = i * partSize
+    const end = Math.min(start + partSize, totalSize)
+    const partBuffer = buffer.slice(start, end)
+    // md5() returns a 32-char hex string; convert to 16 raw bytes
+    const hex = md5(new Uint8Array(partBuffer))
+    for (let j = 0; j < 16; j++) {
+      rawDigests[i * 16 + j] = parseInt(hex.slice(j * 2, j * 2 + 2), 16)
+    }
+  }
+
+  return `${md5(rawDigests)}-${partCount}`
 }
 
 // helper: compute crc32 hex (use js-crc). Accepts ArrayBuffer and returns

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ async function collectMappingOptions(
   const skipModifications = organizeOptions.skipModifications ?? false
   const skipValidation = organizeOptions.skipValidation ?? false
   const hashMethod = organizeOptions.hashMethod
+  const hashPartSize = organizeOptions.hashPartSize
 
   const dateOffset = organizeOptions.dateOffset
 
@@ -214,6 +215,7 @@ async function collectMappingOptions(
     skipValidation,
     dateOffset,
     hashMethod,
+    hashPartSize,
   }
 }
 

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -27,6 +27,7 @@ import type {
 export type TMappingWorkerOptions = TMappingOptions & {
   outputTarget?: TOutputTarget
   hashMethod?: THashMethod
+  hashPartSize?: number
 }
 
 export type ProgressCallback = (message: TProgressMessage) => void
@@ -166,7 +167,7 @@ export async function dispatchMappingJobs(): Promise<void> {
     // if the worker crashes.
     workerCurrentFile.set(mappingWorker, fileInfo)
 
-    const { outputTarget, hashMethod, ...mappingOptions } =
+    const { outputTarget, hashMethod, hashPartSize, ...mappingOptions } =
       // Not partial anymore.
       mappingWorkerOptions as TMappingWorkerOptions
     mappingWorker.postMessage({
@@ -175,6 +176,7 @@ export async function dispatchMappingJobs(): Promise<void> {
       outputTarget: await getHttpOutputHeaders(outputTarget),
       previousFileInfo,
       hashMethod,
+      hashPartSize,
       serializedMappingOptions: serializeMappingOptions(mappingOptions),
     } satisfies MappingRequest)
     workersActive += 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,12 @@ export type OrganizeOptions = {
   // Used in conjunction with fileInfoIndex.
   // Defaults to 'md5'.
   hashMethod?: THashMethod
+  // Part size (in bytes) used by the upstream S3 multipart upload.
+  // Only relevant when hashMethod is 'aws-s3-etag-2025': files larger than
+  // this threshold produce a composite ETag-style hash; smaller files produce
+  // a plain MD5. Defaults to 5 * 1024 * 1024 (5 MB), matching the
+  // @aws-sdk/lib-storage Upload class default.
+  hashPartSize?: number
   // optional previous file info map keyed by "path/name"
   // if set, used to determine if mapping can be skipped for files that appear unchanged
   fileInfoIndex?: TFileInfoIndex
@@ -70,7 +76,17 @@ export type OrganizeOptions = {
   | { inputType: 's3'; inputS3Bucket: TS3BucketOptions }
 )
 
-export type THashMethod = 'crc64' | 'crc32' | 'sha256' | 'md5'
+export type THashMethod =
+  | 'crc64'
+  | 'crc32'
+  | 'sha256'
+  | 'md5'
+  // Matches S3 ETag format: plain MD5 for single-part uploads, composite
+  // md5(concat(md5(part1)...md5(partN)))-N for multipart uploads.
+  // Uses hashPartSize to determine the part boundary (defaults to 5 MB).
+  // The multipart ETag algorithm is undocumented by AWS but empirically
+  // stable since ~2006 for SSE-S3 (AES256) encrypted objects.
+  | 'aws-s3-etag-2025'
 
 // Function that provides HTTP headers
 // Useful when headers contain authorization tokens that may expire


### PR DESCRIPTION
## Summary
- Prefer nullish coalescing (`??`) over logical OR (`||`) for default values across the codebase
- Change default `hashMethod` from `crc64` to `md5` for S3 ETag compatibility
- Add `aws-s3-etag-2025` hash method that reproduces S3's ETag format for both single-part (plain MD5) and multipart uploads
- Thread `hashPartSize` option from `OrganizeOptions` through the worker pool to `curateOne` and `hash()`

Closes #237