### PR TITLE
perf: eliminate per-worker fileInfoIndex copies (#238)

### DIFF
--- a/src/applyMappingsWorker.ts
+++ b/src/applyMappingsWorker.ts
@@ -1,33 +1,32 @@
 import { curateOne } from './curateOne'
 import { deserializeMappingOptions } from './serializeMappingOptions'
 import {
-  OUTPUT_FILE_PREFIX,
   type TFileInfo,
-  type TFileInfoIndex,
   type THashMethod,
   type TOutputTarget,
   type TSerializedMappingOptions,
 } from './types'
 import { fixupNodeWorkerEnvironment } from './worker'
 
-export type MappingRequest =
-  | {
-      request: 'apply'
-      fileInfo: TFileInfo
-      outputTarget?: TOutputTarget
-      previousFileInfo?: {
-        size?: number
-        mtime?: string
-        preMappedHash?: string
-      }
-      hashMethod?: THashMethod
-      hashPartSize?: number
-      serializedMappingOptions: TSerializedMappingOptions
-    }
-  | {
-      request: 'fileInfoIndex'
-      fileInfoIndex?: TFileInfoIndex
-    }
+export type MappingRequest = {
+  request: 'apply'
+  fileInfo: TFileInfo
+  outputTarget?: TOutputTarget
+  previousFileInfo?: {
+    size?: number
+    mtime?: string
+    preMappedHash?: string
+  }
+  hashMethod?: THashMethod
+  hashPartSize?: number
+  serializedMappingOptions: TSerializedMappingOptions
+}
+
+/** Response sent back from the main thread for a fileInfoIndex lookup. */
+export type LookupResponse = {
+  response: 'lookupResult'
+  postMappedHash?: string
+}
 
 /**
  * Safely serialize an error for postMessage to avoid DataCloneError.
@@ -71,60 +70,88 @@ function postErrorResponse(error: unknown, fileInfo: TFileInfo): void {
   }
 }
 
-let postMappedFileInfo: TFileInfoIndex | undefined
+/**
+ * Pending lookup resolve function. At most one lookup is in flight at a time
+ * because each worker processes one file at a time sequentially.
+ */
+let pendingLookupResolve:
+  | ((result: { postMappedHash?: string } | undefined) => void)
+  | null = null
+
+/**
+ * Request a postMappedHash lookup from the main thread.
+ * Returns a Promise that resolves when the main thread replies with
+ * a 'lookupResult' message.
+ */
+function lookupMappedFileInfo(
+  outputPath: string,
+): Promise<{ postMappedHash?: string } | undefined> {
+  return new Promise((resolve) => {
+    pendingLookupResolve = resolve
+    globalThis.postMessage({
+      response: 'lookup',
+      outputPath,
+    })
+  })
+}
 
 fixupNodeWorkerEnvironment()
   .then(() => {
     globalThis.addEventListener(
       'message',
-      (event: MessageEvent<MappingRequest>) => {
-        switch (event.data.request) {
-          case 'fileInfoIndex': {
-            postMappedFileInfo = event.data.fileInfoIndex
-            break
+      (event: MessageEvent<MappingRequest | LookupResponse>) => {
+        // Handle lookup response from main thread
+        if (
+          'response' in event.data &&
+          event.data.response === 'lookupResult'
+        ) {
+          const resolve = pendingLookupResolve
+          pendingLookupResolve = null
+          if (resolve) {
+            const hash = (event.data as LookupResponse).postMappedHash
+            resolve(hash ? { postMappedHash: hash } : undefined)
           }
-          case 'apply': {
-            const { serializedMappingOptions } = event.data
-            const mappingOptions = deserializeMappingOptions(
-              serializedMappingOptions,
-            )
+          return
+        }
 
-            const fileInfo = event.data.fileInfo
-            try {
-              curateOne({
-                fileInfo,
-                outputTarget: event.data.outputTarget ?? {},
-                hashMethod: event.data.hashMethod,
-                hashPartSize: event.data.hashPartSize,
-                mappingOptions,
-                previousSourceFileInfo: event.data.previousFileInfo,
-                previousMappedFileInfo: (targetName) => {
-                  const hash =
-                    postMappedFileInfo?.[OUTPUT_FILE_PREFIX + targetName]
-                  return hash
-                },
+        const data = event.data as MappingRequest
+        if (data.request !== 'apply') {
+          console.error(
+            `Unknown request ${(data as { request: string }).request}`,
+          )
+          return
+        }
+
+        const { serializedMappingOptions } = data
+        const mappingOptions = deserializeMappingOptions(
+          serializedMappingOptions,
+        )
+
+        const fileInfo = data.fileInfo
+        try {
+          curateOne({
+            fileInfo,
+            outputTarget: data.outputTarget ?? {},
+            hashMethod: data.hashMethod,
+            hashPartSize: data.hashPartSize,
+            mappingOptions,
+            previousSourceFileInfo: data.previousFileInfo,
+            previousMappedFileInfo: lookupMappedFileInfo,
+          })
+            .then((mapResults) => {
+              // Send finished message for completion
+              globalThis.postMessage({
+                response: 'finished',
+                mapResults: mapResults,
               })
-                .then((mapResults) => {
-                  // Send finished message for completion
-                  globalThis.postMessage({
-                    response: 'finished',
-                    mapResults: mapResults,
-                  })
-                })
-                .catch((error) => {
-                  // also catch promise rejections
-                  postErrorResponse(error, fileInfo)
-                })
-            } catch (error) {
+            })
+            .catch((error) => {
+              // also catch promise rejections
               postErrorResponse(error, fileInfo)
-              // no need to throw here, it would terminate the worker
-            }
-            break
-          }
-          default:
-            console.error(
-              `Unknown request ${(event.data as { request: string }).request}`,
-            )
+            })
+        } catch (error) {
+          postErrorResponse(error, fileInfo)
+          // no need to throw here, it would terminate the worker
         }
       },
     )

--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -33,11 +33,12 @@ export type TCurateOneArgs = {
   // once it is known.
   // If this callback is provided and it returns a postMappedHash that matches
   // what curateOne generated, then the output file is not written again.
-  previousMappedFileInfo?: (mappedFileName: string) =>
+  previousMappedFileInfo?: (mappedFileName: string) => Promise<
     | {
         postMappedHash?: string
       }
     | undefined
+  >
 }
 
 export async function curateOne({
@@ -357,7 +358,8 @@ export async function curateOne({
     fileArrayBuffer = null
 
     const previousPostMappedHash = previousMappedFileInfo
-      ? previousMappedFileInfo(clonedMapResults.outputFilePath!)?.postMappedHash
+      ? (await previousMappedFileInfo(clonedMapResults.outputFilePath!))
+          ?.postMappedHash
       : undefined
 
     if (

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -19,6 +19,7 @@ import type {
   TFileInfoIndex,
   THashMethod,
 } from './types'
+import { OUTPUT_FILE_PREFIX } from './types'
 
 // -------------------------------------------------------------------------
 // Types
@@ -60,8 +61,8 @@ let lastWorkerProgressTime = 0
 // before finishing, to avoid orphaning in-flight replacements.
 let pendingReplacements = 0
 
-// Stored fileInfoIndex from initializeMappingWorkers, needed when spawning
-// replacement workers after a crash.
+// Stored fileInfoIndex from initializeMappingWorkers, used for lookup
+// responses when workers query for previousMappedFileInfo.
 let currentFileInfoIndex: TFileInfoIndex | undefined
 
 // Shared state accessed by both scan worker (in index.ts) and dispatch (here).
@@ -146,9 +147,7 @@ export async function initializeMappingWorkers(
   const effectiveWorkerCount =
     workerCount ?? Math.min(await getHardwareConcurrency(), 8)
   const workers = await Promise.all(
-    Array.from({ length: effectiveWorkerCount }, () =>
-      createMappingWorker(fileInfoIndex),
-    ),
+    Array.from({ length: effectiveWorkerCount }, () => createMappingWorker()),
   )
   availableMappingWorkers.push(...workers)
 }
@@ -310,7 +309,7 @@ function recoverCrashedWorker(
   // Spawn a replacement worker so the pool doesn't shrink permanently.
   // A directory with many problematic files could otherwise kill all workers.
   pendingReplacements += 1
-  void createMappingWorker(currentFileInfoIndex)
+  void createMappingWorker()
     .then((worker) => {
       pendingReplacements -= 1
       availableMappingWorkers.push(worker)
@@ -328,9 +327,7 @@ function recoverCrashedWorker(
  * Used by both initializeMappingWorkers (initial pool) and recoverCrashedWorker
  * (replacement after crash).
  */
-async function createMappingWorker(
-  fileInfoIndex?: TFileInfoIndex,
-): Promise<Worker> {
+async function createMappingWorker(): Promise<Worker> {
   const mappingWorker = await createWorker(
     new URL('./applyMappingsWorker.js', import.meta.url),
     { type: 'module' },
@@ -362,20 +359,21 @@ async function createMappingWorker(
     })
   }
 
-  if (fileInfoIndex !== undefined) {
-    const postMappedOnly = Object.fromEntries(
-      Object.entries(fileInfoIndex).filter(
-        ([_key, value]) => !!value.postMappedHash,
-      ),
-    )
-
-    mappingWorker.postMessage({
-      request: 'fileInfoIndex',
-      fileInfoIndex: postMappedOnly,
-    })
-  }
-
   mappingWorker.addEventListener('message', (event) => {
+    // Handle lookup requests from the worker. The worker sends these when
+    // curateOne needs to check if a mapped file was already uploaded
+    // (previousMappedFileInfo). The index is kept on the main thread to
+    // avoid copying 200k+ entries to every worker.
+    if (event.data.response === 'lookup') {
+      const outputPath: string = event.data.outputPath
+      const entry = currentFileInfoIndex?.[OUTPUT_FILE_PREFIX + outputPath]
+      mappingWorker.postMessage({
+        response: 'lookupResult',
+        postMappedHash: entry?.postMappedHash,
+      })
+      return
+    }
+
     // Any message from a worker means progress is being made.
     lastWorkerProgressTime = Date.now()
     workerCurrentFile.delete(mappingWorker)


### PR DESCRIPTION
## Summary
- Keep `fileInfoIndex` on the main thread instead of copying it to every mapping worker
- Workers request `postMappedHash` lookups via a sub-millisecond message roundtrip
- Eliminates ~800 MB of duplicated heap with 8 workers and 200k+ remote files
- Tested with 447k files: peak memory dropped from 3.1 GB to 1.0 GB

Depends on #237 PR (already rebased on top).

Closes #238