### PR TITLE
feat: add AbortSignal support to curateMany

### DIFF
--- a/src/abortSignal.test.ts
+++ b/src/abortSignal.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Integration tests for AbortSignal support in curateMany.
+ *
+ * Both scan and mapping workers are mocked (same pattern as
+ * workerCrashRecovery.test.ts). Tests verify that aborting curateMany:
+ * - Terminates all workers
+ * - Rejects with a DOMException (name: 'AbortError')
+ * - Leaves module-level state clean for subsequent runs
+ *
+ * IMPORTANT: The mapping worker pool uses LIFO (stack) dispatch -- the last
+ * worker pushed to availableMappingWorkers is the first to receive work.
+ */
+
+import { jest } from '@jest/globals'
+import { cpus } from 'node:os'
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  MockWorker,
+  configureMockMappingWorkers,
+  resetMockWorkers,
+  getMockWorkersCreated,
+  getNextMockBehavior,
+  registerMockWorker,
+} from '../testutils/mockMappingWorker'
+import type { MockWorkerBehavior } from '../testutils/mockMappingWorker'
+import { MockScanWorker } from '../testutils/mockScanWorker'
+import {
+  createTestDicomDir,
+  cleanupTestDicomDir,
+} from '../testutils/dicomFixtures'
+
+// ---------------------------------------------------------------------------
+// Slow scan worker: emits files with a configurable delay between each.
+// This lets us abort mid-scan reliably. Standalone implementation that
+// mirrors MockScanWorker's interface without inheriting (emit is private).
+// ---------------------------------------------------------------------------
+
+function listFiles(dir: string, base: string = ''): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = base ? `${base}/${entry.name}` : entry.name
+    if (entry.isDirectory()) {
+      files.push(...listFiles(join(dir, entry.name), rel))
+    } else {
+      files.push(rel)
+    }
+  }
+  return files
+}
+
+class SlowScanWorker {
+  public onerror: ((event: any) => void) | null = null
+  public terminated = false
+  public emissionDelay: number
+
+  private messageListeners: ((event: { data: any }) => void)[] = []
+
+  constructor(emissionDelay = 50) {
+    this.emissionDelay = emissionDelay
+  }
+
+  addEventListener(event: string, listener: any): void {
+    if (event === 'message') {
+      this.messageListeners.push(listener)
+    }
+  }
+
+  on(event: string, listener: any): void {
+    if (event === 'message') {
+      this.messageListeners.push(listener)
+    }
+  }
+
+  postMessage(data: any): void {
+    if (this.terminated) return
+    if (data.request !== 'scan') return
+
+    const scanDir = data.path || data.directoryHandle
+    if (!scanDir || typeof scanDir !== 'string') {
+      this.emit({
+        response: 'error',
+        error: 'No path provided to slow scan worker',
+      })
+      return
+    }
+
+    const files = listFiles(scanDir)
+
+    let i = 0
+    const emitNext = () => {
+      if (this.terminated) return
+      if (i < files.length) {
+        const relPath = files[i]
+        const parts = relPath.split('/')
+        const name = parts.pop()!
+        const path = parts.join('/')
+        const fullPath = join(scanDir, relPath)
+        const stat = statSync(fullPath)
+
+        this.emit({
+          response: 'file',
+          fileInfo: {
+            kind: 'path',
+            path: join(scanDir, path),
+            name,
+            size: stat.size,
+          },
+        })
+        i++
+        setTimeout(emitNext, this.emissionDelay)
+      } else {
+        this.emit({ response: 'done' })
+      }
+    }
+    setTimeout(emitNext, this.emissionDelay)
+  }
+
+  terminate(): void {
+    this.terminated = true
+  }
+
+  private emit(data: any): void {
+    for (const listener of this.messageListeners) {
+      listener({ data })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test setup: mock worker factory
+// ---------------------------------------------------------------------------
+
+// Track whether we're using slow scan workers for specific tests
+let useSlowScanWorker = false
+let slowScanDelay = 50
+let scanWorkerInstance: MockScanWorker | SlowScanWorker | undefined
+
+jest.unstable_mockModule('./worker', () => ({
+  createWorker: async (scriptPath: string | URL, _options?: any) => {
+    const urlStr = scriptPath.toString()
+
+    if (urlStr.includes('scanDirectoryWorker')) {
+      if (useSlowScanWorker) {
+        scanWorkerInstance = new SlowScanWorker(slowScanDelay)
+      } else {
+        scanWorkerInstance = new MockScanWorker()
+      }
+      return scanWorkerInstance as unknown as Worker
+    }
+
+    const behavior = getNextMockBehavior()
+    const mock = new MockWorker(behavior)
+    registerMockWorker(mock)
+    return mock as unknown as Worker
+  },
+  fixupNodeWorkerEnvironment: async () => {},
+}))
+
+const { curateMany } = await import('./index')
+
+const WORKER_COUNT = Math.min(cpus().length, 8)
+
+function minimalSpec() {
+  return {
+    version: '3.0' as const,
+    hostProps: {
+      protocolNumber: 'abort-signal-test',
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AbortSignal support', () => {
+  let testDir: string
+
+  beforeAll(() => {
+    testDir = createTestDicomDir(10)
+  })
+
+  afterAll(() => {
+    cleanupTestDicomDir(testDir)
+  })
+
+  afterEach(() => {
+    resetMockWorkers()
+    useSlowScanWorker = false
+    slowScanDelay = 50
+    scanWorkerInstance = undefined
+  })
+
+  it('rejects immediately with a pre-aborted signal (no workers created)', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const controller = new AbortController()
+    controller.abort()
+
+    try {
+      await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: testDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          signal: controller.signal,
+        },
+        () => {},
+      )
+      // Should not reach here
+      expect(true).toBe(false)
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(DOMException)
+      expect(error.name).toBe('AbortError')
+      expect(error.message).toBe('The operation was aborted.')
+    }
+
+    // No mapping workers should have been created
+    expect(getMockWorkersCreated()).toHaveLength(0)
+  })
+
+  it('aborts during scanning phase — workers terminated, rejects with AbortError', async () => {
+    useSlowScanWorker = true
+    slowScanDelay = 30
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const controller = new AbortController()
+
+    // Count progress messages to know when files start flowing
+    let progressCount = 0
+    const progressCallback = () => {
+      progressCount++
+      // Abort after a few files have been dispatched
+      if (progressCount >= 2) {
+        controller.abort()
+      }
+    }
+
+    try {
+      await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: testDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          signal: controller.signal,
+        },
+        progressCallback,
+      )
+      expect(true).toBe(false)
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(DOMException)
+      expect(error.name).toBe('AbortError')
+    }
+
+    // Scan worker should have been terminated
+    expect(scanWorkerInstance!.terminated).toBe(true)
+
+    // All mapping workers should be terminated
+    const allWorkers = getMockWorkersCreated()
+    for (const worker of allWorkers) {
+      expect(worker.terminated).toBe(true)
+    }
+
+    // Should have processed fewer than all 10 files
+    expect(progressCount).toBeLessThan(10)
+  })
+
+  it('aborts during mapping phase (scan complete) — rejects with AbortError', async () => {
+    // Use fast scan so all files are queued quickly
+    useSlowScanWorker = false
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const controller = new AbortController()
+
+    let progressCount = 0
+    const progressCallback = () => {
+      progressCount++
+      // Abort after a few files are mapped (but before all 10)
+      if (progressCount >= 3) {
+        controller.abort()
+      }
+    }
+
+    try {
+      await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: testDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          signal: controller.signal,
+        },
+        progressCallback,
+      )
+      expect(true).toBe(false)
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(DOMException)
+      expect(error.name).toBe('AbortError')
+    }
+
+    // All mapping workers should be terminated
+    const allWorkers = getMockWorkersCreated()
+    for (const worker of allWorkers) {
+      expect(worker.terminated).toBe(true)
+    }
+  })
+
+  it('abort after natural completion is a no-op', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const controller = new AbortController()
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        signal: controller.signal,
+      },
+      () => {},
+    )
+
+    // Now abort after completion
+    controller.abort()
+
+    // The original result should be intact
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+    expect(result.mapResultsList).toHaveLength(10)
+  })
+
+  it('sequential calls: abort then re-run completes successfully', async () => {
+    // First run: abort it
+    useSlowScanWorker = true
+    slowScanDelay = 30
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const controller1 = new AbortController()
+
+    let progressCount = 0
+    try {
+      await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: testDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          signal: controller1.signal,
+        },
+        () => {
+          progressCount++
+          if (progressCount >= 2) {
+            controller1.abort()
+          }
+        },
+      )
+      expect(true).toBe(false)
+    } catch (error: any) {
+      expect(error.name).toBe('AbortError')
+    }
+
+    // Reset mocks for the second run
+    resetMockWorkers()
+    useSlowScanWorker = false
+    scanWorkerInstance = undefined
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    // Second run: should complete normally with clean state
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+    expect(result.mapResultsList).toHaveLength(10)
+
+    const errors = result.mapResultsList!.filter(
+      (r) => r.errors && r.errors.length > 0,
+    )
+    expect(errors).toHaveLength(0)
+  })
+
+  it('abort during crash recovery — no zombie replacement workers', async () => {
+    // Configure one crash worker at the end (LIFO: it receives first file)
+    const behaviors: MockWorkerBehavior[] = [
+      ...Array(WORKER_COUNT - 1).fill('normal' as MockWorkerBehavior),
+      'crash-onerror',
+    ]
+    configureMockMappingWorkers(behaviors)
+
+    const controller = new AbortController()
+
+    let progressCount = 0
+    let aborted = false
+
+    try {
+      await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: testDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          signal: controller.signal,
+        },
+        () => {
+          progressCount++
+          // Abort shortly after the crash worker has received its file
+          // and crash recovery is likely in progress
+          if (progressCount >= 1 && !aborted) {
+            aborted = true
+            controller.abort()
+          }
+        },
+      )
+      expect(true).toBe(false)
+    } catch (error: any) {
+      expect(error.name).toBe('AbortError')
+    }
+
+    // Give the async replacement worker creation chain time to settle.
+    // The recoverCrashedWorker spawns a replacement asynchronously — we need
+    // the .then() callback (which terminates the zombie) to execute.
+    await new Promise((r) => setTimeout(r, 50))
+
+    // All initially created mapping workers should be terminated
+    const allWorkers = getMockWorkersCreated()
+    for (const worker of allWorkers) {
+      expect(worker.terminated).toBe(true)
+    }
+
+    // Now run again to verify no zombie state
+    resetMockWorkers()
+    scanWorkerInstance = undefined
+    useSlowScanWorker = false
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   getLastWorkerProgressTime,
   setScanResumeCallback,
   markScanPaused,
+  terminateAllWorkers,
 } from './mappingWorkerPool'
 
 export type { ProgressCallback } from './mappingWorkerPool'
@@ -265,7 +266,19 @@ async function curateMany(
   organizeOptions: OrganizeOptions,
   onProgress?: ProgressCallback,
 ): Promise<TProgressMessageDone> {
+  // Early rejection for pre-aborted signal — don't create any workers.
+  if (organizeOptions.signal?.aborted) {
+    return Promise.reject(
+      new DOMException('The operation was aborted.', 'AbortError'),
+    )
+  }
+
   return new Promise<TProgressMessageDone>(async (resolve, reject) => {
+    // Prevents double-settle when abort races with natural completion.
+    let settled = false
+
+    const signal = organizeOptions.signal
+
     // Stall watchdog: if no mapping worker at all has reported back for 10
     // minutes (i.e., all active workers are stuck), terminate them and count
     // their in-flight files as mapping errors. This guards against undetectable
@@ -301,15 +314,53 @@ async function curateMany(
     const progressCallback: ProgressCallback = (msg) => {
       onProgress?.(msg)
 
-      if (msg.response === 'done') {
+      if (msg.response === 'done' && !settled) {
+        settled = true
         clearInterval(stallWatchdog)
+        signal?.removeEventListener('abort', onAbort)
         resolve(msg)
       }
     }
 
     const rejectCallback = (reason: Error) => {
+      if (settled) return
+      settled = true
       clearInterval(stallWatchdog)
+      signal?.removeEventListener('abort', onAbort)
       reject(reason)
+    }
+
+    // Reference to the scan worker, hoisted so the abort handler can
+    // terminate it. Assigned later when a directory/path/s3 input is used.
+    let fileListWorker: Worker | undefined
+
+    const onAbort = () => {
+      // Terminate the scan worker if it exists
+      try {
+        fileListWorker?.terminate()
+      } catch {
+        /* already terminated */
+      }
+
+      // Hard-terminate all mapping workers and reset pool state
+      terminateAllWorkers()
+
+      // Reject with standard AbortError
+      rejectCallback(
+        new DOMException('The operation was aborted.', 'AbortError'),
+      )
+    }
+
+    if (signal) {
+      // Re-check in case abort happened between the early check and here
+      if (signal.aborted) {
+        clearInterval(stallWatchdog)
+        rejectCallback(
+          new DOMException('The operation was aborted.', 'AbortError'),
+        )
+        return
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
     }
 
     try {
@@ -337,12 +388,12 @@ async function curateMany(
         organizeOptions.inputType === 'path' ||
         organizeOptions.inputType === 's3'
       ) {
-        const fileListWorker = await initializeFileListWorker(rejectCallback)
+        fileListWorker = await initializeFileListWorker(rejectCallback)
 
         // Wire up backpressure resume: when the dispatch loop drains the
         // queue below the low-water mark, it calls this to resume scanning.
         setScanResumeCallback(() => {
-          fileListWorker.postMessage({ request: 'resume' })
+          fileListWorker!.postMessage({ request: 'resume' })
         })
         let specExcludedFiletypes: string[] | undefined
         let noDicomSignatureCheck = false
@@ -404,7 +455,7 @@ async function curateMany(
 
       dispatchMappingJobs()
     } catch (error) {
-      reject(error)
+      rejectCallback(error as Error)
     }
   })
 }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -61,6 +61,11 @@ let lastWorkerProgressTime = 0
 // before finishing, to avoid orphaning in-flight replacements.
 let pendingReplacements = 0
 
+// Set to true when curateMany is aborted via AbortSignal. Guards dispatch,
+// crash recovery, and worker message handlers against acting on stale state
+// after teardown.
+let aborted = false
+
 // Stored fileInfoIndex from initializeMappingWorkers, used for lookup
 // responses when workers query for previousMappedFileInfo.
 let currentFileInfoIndex: TFileInfoIndex | undefined
@@ -122,6 +127,47 @@ export function markScanPaused(): void {
 }
 
 /**
+ * Hard-terminate all workers (idle and active) and reset pool state.
+ * Called when curateMany is aborted via AbortSignal. Equivalent to a
+ * tab reload — partially written files are handled by hash checks on
+ * the next run.
+ */
+export function terminateAllWorkers(): void {
+  aborted = true
+
+  // Terminate idle workers
+  while (availableMappingWorkers.length) {
+    availableMappingWorkers.pop()!.terminate()
+  }
+
+  // Terminate active workers (those with an in-flight file)
+  for (const [worker] of workerCurrentFile) {
+    try {
+      worker.terminate()
+    } catch {
+      /* already terminated */
+    }
+  }
+  workerCurrentFile.clear()
+
+  // Clear the queue and reset counters
+  filesToProcess.length = 0
+  workersActive = 0
+  pendingReplacements = 0
+  directoryScanFinished = false
+  scanPaused = false
+  scanResumeCallback = null
+}
+
+/**
+ * Whether the current run has been aborted. Used by worker message handlers
+ * to bail out on messages arriving after teardown.
+ */
+export function isAborted(): boolean {
+  return aborted
+}
+
+/**
  * Initialize the mapping worker pool. Call once per curateMany invocation.
  */
 export async function initializeMappingWorkers(
@@ -135,6 +181,7 @@ export async function initializeMappingWorkers(
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
   pendingReplacements = 0
+  aborted = false
   workerCurrentFile.clear()
   lastWorkerProgressTime = Date.now()
   currentFileInfoIndex = fileInfoIndex
@@ -158,6 +205,8 @@ export async function initializeMappingWorkers(
  * replacements, scan finished) and emits the 'done' progress message.
  */
 export async function dispatchMappingJobs(): Promise<void> {
+  if (aborted) return
+
   while (filesToProcess.length > 0 && availableMappingWorkers.length > 0) {
     const { fileInfo, previousFileInfo } = filesToProcess.pop()!
     const mappingWorker = availableMappingWorkers.pop()!
@@ -262,6 +311,9 @@ function recoverCrashedWorker(
   mappingWorker: Worker,
   errorMessage: string,
 ): void {
+  // Bail out if processing has been aborted — no recovery needed.
+  if (aborted) return
+
   // Guard against double-recovery (e.g., both onerror and on('exit') firing
   // for the same crash). Without this, workersActive could go negative.
   if (!workerCurrentFile.has(mappingWorker)) {
@@ -312,6 +364,12 @@ function recoverCrashedWorker(
   void createMappingWorker()
     .then((worker) => {
       pendingReplacements -= 1
+      // If processing was aborted while the replacement was being created,
+      // terminate it immediately instead of adding it to the pool.
+      if (aborted) {
+        worker.terminate()
+        return
+      }
       availableMappingWorkers.push(worker)
       dispatchMappingJobs()
     })
@@ -360,6 +418,9 @@ async function createMappingWorker(): Promise<Worker> {
   }
 
   mappingWorker.addEventListener('message', (event) => {
+    // Ignore messages from workers after abort — the pool is torn down.
+    if (aborted) return
+
     // Handle lookup requests from the worker. The worker sends these when
     // curateOne needs to check if a mapped file was already uploaded
     // (previousMappedFileInfo). The index is kept on the main thread to

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,11 @@ export type OrganizeOptions = {
   // Defaults to the platform's hardware concurrency (capped at 8).
   // Reducing this limits peak memory usage at the cost of slower throughput.
   workerCount?: number
+  // Optional AbortSignal to cancel processing. When aborted, all workers are
+  // hard-terminated and curateMany rejects with a DOMException (name: 'AbortError').
+  // Equivalent to reloading the page — partially written files are detected and
+  // re-processed on the next run via the hash-based fileInfoIndex check.
+  signal?: AbortSignal
 } & (
   | { inputType: 'directory'; inputDirectory: FileSystemDirectoryHandle }
   | { inputType: 'files'; inputFiles: File[] }


### PR DESCRIPTION
## Summary

Closes #243

- Adds optional `signal?: AbortSignal` to `OrganizeOptions` so consumers can cancel `curateMany` mid-execution
- On abort: hard-terminates all workers (scan + mapping), rejects with `DOMException` (name: `'AbortError'`), fully resets module-level state for clean re-invocation
- Follows web platform convention (`fetch`, `ReadableStream`) — equivalent to a tab reload; partially written files are handled by hash-based `fileInfoIndex` on the next run

## Changes

| File | What |
|---|---|
| `src/types.ts` | Add `signal?: AbortSignal` to `OrganizeOptions` |
| `src/mappingWorkerPool.ts` | Add `aborted` flag, `terminateAllWorkers()`, guards in `dispatchMappingJobs()`, `recoverCrashedWorker()`, worker message handler, and replacement worker callback |
| `src/index.ts` | Wire abort listener into `curateMany` with `settled` flag to prevent double-settle races, early rejection for pre-aborted signals |
| `src/abortSignal.test.ts` | 6 integration tests: pre-aborted signal, abort during scan, abort during mapping, post-completion no-op, sequential abort-then-rerun, abort during crash recovery |
| `PLAN.md` | Implementation plan |
| `IMPLEMENTED.md` | Implementation details for consumers |

## Test results

All 130 tests pass across 16 suites. Zero regressions.