### PR TITLE
fix: separate upload errors from DICOM validation errors (#248)

### DIFF
--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -2,15 +2,15 @@ import * as dcmjs from 'dcmjs'
 import createNestedDirectories from './createNestedDirectories'
 import curateDict from './curateDict'
 import { fetchWithRetry } from './fetchWithRetry'
+import { hash } from './hash'
+import { loadS3Client } from './s3Client'
 import type {
   TFileInfo,
   THashMethod,
-  TOutputTarget,
   TMappingOptions,
   TMapResults,
+  TOutputTarget,
 } from './types'
-import { hash } from './hash'
-import { loadS3Client } from './s3Client'
 
 export type TCurateOneArgs = {
   fileInfo: TFileInfo
@@ -278,7 +278,6 @@ export async function curateOne({
 
       return mapResults
     }
-
     // 6) perform mapping
 
     ;({ dicomData: mappedDicomData, mapResults: clonedMapResults } = curateDict(
@@ -464,8 +463,8 @@ export async function curateOne({
           console.error(
             `Upload failed for ${uploadUrl}: ${resp.status} ${resp.statusText}`,
           )
-          clonedMapResults.errors = clonedMapResults.errors ?? []
-          clonedMapResults.errors.push(
+          clonedMapResults.uploadErrors = clonedMapResults.uploadErrors ?? []
+          clonedMapResults.uploadErrors.push(
             `Upload failed: ${resp.status} ${resp.statusText}`,
           )
         } else {
@@ -479,8 +478,8 @@ export async function curateOne({
         }
       } catch (e) {
         console.error('Upload error', e)
-        clonedMapResults.errors = clonedMapResults.errors ?? []
-        clonedMapResults.errors.push(
+        clonedMapResults.uploadErrors = clonedMapResults.uploadErrors ?? []
+        clonedMapResults.uploadErrors.push(
           `Upload error: ${e instanceof Error ? e.message : String(e)}`,
         )
       }
@@ -531,8 +530,8 @@ export async function curateOne({
         }
       } catch (e) {
         console.error('S3 Upload error', e)
-        clonedMapResults.errors = clonedMapResults.errors ?? []
-        clonedMapResults.errors.push(
+        clonedMapResults.uploadErrors = clonedMapResults.uploadErrors ?? []
+        clonedMapResults.uploadErrors.push(
           `S3 Upload error: ${e instanceof Error ? e.message : String(e)}`,
         )
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { TColumnMappings, TMappedValues, Row } from './csvMapping'
 import type { TNaturalData } from 'dcmjs'
 import type { SpecPart } from './composeSpecs'
+import type { Row, TColumnMappings, TMappedValues } from './csvMapping'
 
 export type Iso8601Duration = string
 
@@ -199,6 +199,9 @@ export type TMapResults = {
   }
   anomalies: string[]
   errors: string[]
+  /** Upload/write failures only (retryable). Separate from `errors` which
+   *  contains DICOM validation issues that cannot be resolved by retrying. */
+  uploadErrors?: string[]
   quarantine: { [objectPath: string]: string }
   listing?: {
     info: TMappingTwoPassInfo[]


### PR DESCRIPTION
## Summary

- Add `uploadErrors?: string[]` to `TMapResults` for retryable upload/write failures
- Move upload failure messages from `errors[]` to `uploadErrors[]` in `curateOne.ts` (HTTP failure, HTTP catch, S3 catch paths)
- `errors[]` now strictly contains DICOM validation issues, not upload failures

Closes #248