### PR TITLE
fix: emit periodic count messages in normal feeding mode (#247)

### DIFF
--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -6,20 +6,20 @@
  * the stall watchdog. Extracted from index.ts for maintainability.
  */
 
-import { serializeMappingOptions } from './serializeMappingOptions'
-import { getHttpInputHeaders, getHttpOutputHeaders } from './httpHeaders'
-import { createWorker } from './worker'
 import type { MappingRequest } from './applyMappingsWorker'
+import { getHttpInputHeaders, getHttpOutputHeaders } from './httpHeaders'
+import { serializeMappingOptions } from './serializeMappingOptions'
 import type {
-  TMappingOptions,
-  TMapResults,
   TFileInfo,
-  TProgressMessage,
-  TOutputTarget,
   TFileInfoIndex,
   THashMethod,
+  TMappingOptions,
+  TMapResults,
+  TOutputTarget,
+  TProgressMessage,
 } from './types'
 import { OUTPUT_FILE_PREFIX } from './types'
+import { createWorker } from './worker'
 
 // -------------------------------------------------------------------------
 // Types
@@ -98,7 +98,7 @@ let scanPaused = false
 // Total files discovered by the scanner (including those still buffered in the
 // worker). Set via 'count' messages from the scan worker. When available, used
 // in place of the queue-based heuristic for progress reporting.
-let totalDiscoveredFiles: number | undefined = undefined
+let totalDiscoveredFiles: number | undefined
 
 /**
  * Low-water mark for the file processing queue. When the queue size drops
@@ -479,7 +479,7 @@ async function createMappingWorker(): Promise<Worker> {
           console.log(`Finished mapping ${filesMapped} files`)
         }
         break
-      case 'error':
+      case 'error': {
         console.error('Error in mapping worker:', event.data.error)
         availableMappingWorkers.push(mappingWorker)
 
@@ -508,6 +508,7 @@ async function createMappingWorker(): Promise<Worker> {
         dispatchMappingJobs()
 
         break
+      }
       default:
         console.error(`Unknown response from worker ${event.data.response}`)
     }

--- a/src/scanDirectoryWorker.ts
+++ b/src/scanDirectoryWorker.ts
@@ -2,10 +2,6 @@ import { loadS3Client } from './s3Client'
 import type { TFileInfo, TFileInfoIndex, TS3BucketOptions } from './types'
 import { fixupNodeWorkerEnvironment } from './worker'
 
-// For editor linter to treat the file as an es module, avoiding the error on
-// keepScanning being redeclared
-export {}
-
 // Case-insensitive filetypes to ALWAYS exclude from processing
 const DEFAULT_EXCLUDED_FILETYPES = [
   'dicomdir',
@@ -568,7 +564,7 @@ async function scanS3Bucket(bucketOptions: TS3BucketOptions) {
     })
 
     // Page through the S3 bucket listing using ContinuationToken
-    let continuationToken: string | undefined = undefined
+    let continuationToken: string | undefined
 
     do {
       const listCommand = new s3.ListObjectsV2Command({
@@ -716,6 +712,14 @@ async function scanDirectory(dir: FileSystemDirectoryHandle) {
             },
             previousFileInfo: prev,
           } satisfies FileScanMsg)
+          // Periodically sync totalDiscovered with the main thread so
+          // progress reporting stays accurate after exiting counting mode.
+          if (totalDiscovered % 100 === 0) {
+            globalThis.postMessage({
+              response: 'count',
+              totalDiscovered,
+            } satisfies FileScanMsg)
+          }
         } else if (fileAnomalies.length > 0) {
           globalThis.postMessage({
             response: 'scanAnomalies',
@@ -749,6 +753,11 @@ async function scanDirectory(dir: FileSystemDirectoryHandle) {
       countingMode = false
       await drainBuffer()
     }
+    // Final count sync so the main thread has the exact total before 'done'
+    globalThis.postMessage({
+      response: 'count',
+      totalDiscovered,
+    } satisfies FileScanMsg)
     globalThis.postMessage({ response: 'done' } satisfies FileScanMsg)
   } catch (error) {
     globalThis.postMessage({
@@ -850,6 +859,14 @@ async function scanDirectoryNode(dirPath: string) {
               },
               previousFileInfo: prev,
             } satisfies FileScanMsg)
+            // Periodically sync totalDiscovered with the main thread so
+            // progress reporting stays accurate after exiting counting mode.
+            if (totalDiscovered % 100 === 0) {
+              globalThis.postMessage({
+                response: 'count',
+                totalDiscovered,
+              } satisfies FileScanMsg)
+            }
           } else if (fileAnomalies.length > 0) {
             globalThis.postMessage({
               response: 'scanAnomalies',
@@ -883,6 +900,11 @@ async function scanDirectoryNode(dirPath: string) {
       countingMode = false
       await drainBuffer()
     }
+    // Final count sync so the main thread has the exact total before 'done'
+    globalThis.postMessage({
+      response: 'count',
+      totalDiscovered,
+    } satisfies FileScanMsg)
     globalThis.postMessage({ response: 'done' } satisfies FileScanMsg)
   } catch (error) {
     globalThis.postMessage({

--- a/src/scannerCounting.test.ts
+++ b/src/scannerCounting.test.ts
@@ -162,6 +162,77 @@ describe('scanner counting during backpressure', () => {
     expect(maxTotalFiles).toBe(200)
   })
 
+  it('processedFiles never exceeds totalFiles in progress messages', async () => {
+    // Regression test: after backpressure drops and the scanner resumes
+    // normal feeding, files discovered in normal mode must still be
+    // reflected in totalFiles. Without the fix, totalDiscoveredFiles on
+    // the main thread stalls at the counting-mode value while
+    // processedFiles (filesMapped) keeps climbing past it.
+    //
+    // We use slow mapping workers (200ms response delay) so the scan
+    // worker fully scans all files before workers start finishing.
+    // With 200 files emitted at ~0ms intervals, the queue fills past
+    // HIGH_WATER_MARK (100) quickly, engaging counting mode. When
+    // workers start finishing and drain the queue, the scanner resumes
+    // in normal mode for any remaining undiscovered files.
+    //
+    // To ensure files remain for normal-mode discovery AFTER the drain,
+    // we use a larger dataset (500 files) and configure the mock scan
+    // worker to emit files with a small delay (2ms), giving workers
+    // time to drain the queue mid-scan so the scanner exits counting
+    // mode before traversing all files.
+    const extraLargeDir = createTestDicomDir(300, {
+      studyDescription: 'Post-Drain Normal Feeding Test',
+      subdirName: 'PDNF-001',
+    })
+
+    try {
+      // Workers start slow (100ms) to build up the queue past
+      // HIGH_WATER_MARK, engaging counting mode. After 20 responses they
+      // switch to instant, draining the queue and releasing backpressure
+      // permanently while the scanner still has files to discover in
+      // normal feeding mode. This reproduces the scenario where
+      // totalDiscoveredFiles stalls at the counting-mode value.
+      configureMockMappingWorkers(Array(WORKER_COUNT).fill('slow-then-fast'), {
+        slowThenFastThreshold: 20,
+      })
+
+      const progressMessages: TProgressMessage[] = []
+      const result = await curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: extraLargeDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+        },
+        (msg) => {
+          progressMessages.push(msg)
+        },
+      )
+
+      expect(result.response).toBe('done')
+      expect(result.processedFiles).toBe(300)
+
+      const progressOnly = progressMessages.filter(
+        (m) => m.response === 'progress',
+      )
+
+      // The invariant: processedFiles should never exceed totalFiles by
+      // more than the periodic count sync interval (100 files). Without
+      // the fix, the overshoot is unbounded (limited only by the number
+      // of files discovered after backpressure drops).
+      const maxOvershoot = Math.max(
+        0,
+        ...progressOnly.map(
+          (m) => (m.processedFiles ?? 0) - (m.totalFiles ?? 0),
+        ),
+      )
+      expect(maxOvershoot).toBeLessThanOrEqual(100)
+    } finally {
+      cleanupTestDicomDir(extraLargeDir)
+    }
+  }, 30000)
+
   it('small dataset works without backpressure — fallback formula used', async () => {
     configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
 

--- a/testutils/mockBackpressureScanWorker.ts
+++ b/testutils/mockBackpressureScanWorker.ts
@@ -250,7 +250,8 @@ export class BackpressureScanWorker {
 
     // No buffered files — continue scanning new files
     if (this.scanIndex >= this.files.length) {
-      // All files scanned and drained — done
+      // All files scanned and drained — emit final count sync then done
+      this.emit({ response: 'count', totalDiscovered: this.totalDiscovered })
       this.emit({ response: 'done' })
       return
     }
@@ -259,6 +260,11 @@ export class BackpressureScanWorker {
     this.totalDiscovered++
     this.emitFileAtIndex(this.scanIndex)
     this.scanIndex++
+    // Periodically sync totalDiscovered with the main thread so
+    // progress reporting stays accurate after exiting counting mode.
+    if (this.totalDiscovered % 100 === 0) {
+      this.emit({ response: 'count', totalDiscovered: this.totalDiscovered })
+    }
     this.scheduleNext()
   }
 

--- a/testutils/mockMappingWorker.ts
+++ b/testutils/mockMappingWorker.ts
@@ -8,6 +8,8 @@
 
 export type MockWorkerBehavior =
   | 'normal'
+  | 'slow'
+  | 'slow-then-fast'
   | 'crash-onerror'
   | 'crash-exit'
   | 'crash-onerror-and-exit'
@@ -16,13 +18,20 @@ export type MockWorkerBehavior =
 let mockBehaviors: MockWorkerBehavior[] = []
 let mockWorkerIndex = 0
 let mockWorkersCreated: MockWorker[] = []
+/** Shared counter for slow-then-fast: after this many total responses,
+ *  workers switch from slow to fast. */
+let slowThenFastThreshold = 0
+let totalResponses = 0
 
 export function configureMockMappingWorkers(
   behaviors: MockWorkerBehavior[],
+  options?: { slowThenFastThreshold?: number },
 ): void {
   mockBehaviors = [...behaviors]
   mockWorkerIndex = 0
   mockWorkersCreated = []
+  slowThenFastThreshold = options?.slowThenFastThreshold ?? 0
+  totalResponses = 0
 }
 
 export function getMockWorkersCreated(): MockWorker[] {
@@ -33,6 +42,8 @@ export function resetMockWorkers(): void {
   mockBehaviors = []
   mockWorkerIndex = 0
   mockWorkersCreated = []
+  slowThenFastThreshold = 0
+  totalResponses = 0
 }
 
 export class MockWorker {
@@ -72,7 +83,9 @@ export class MockWorker {
     const fileInfo = data.fileInfo
 
     switch (this.behavior) {
-      case 'normal': {
+      case 'normal':
+      case 'slow':
+      case 'slow-then-fast': {
         const mapResults = {
           sourceInstanceUID: fileInfo?.name || 'unknown',
           outputFilePath: `output/${fileInfo?.name || 'unknown'}`,
@@ -82,11 +95,22 @@ export class MockWorker {
           quarantine: {},
           fileInfo,
         }
+        // 'slow' adds a fixed delay so the scan worker builds up a queue
+        // and triggers backpressure before workers start returning results.
+        // 'slow-then-fast' starts slow then switches to instant responses
+        // after slowThenFastThreshold total responses across all workers.
+        let delay = 0
+        if (this.behavior === 'slow') {
+          delay = 100
+        } else if (this.behavior === 'slow-then-fast') {
+          delay = totalResponses < slowThenFastThreshold ? 100 : 0
+        }
         setTimeout(() => {
           if (!this.terminated) {
+            totalResponses++
             this.emitMessage({ response: 'finished', mapResults })
           }
-        }, 0)
+        }, delay)
         break
       }
       case 'crash-onerror': {


### PR DESCRIPTION
## Summary

Fixes #247 — `totalFiles` in progress messages stalls after the scanner exits counting mode, causing `processedFiles > totalFiles` in the UI.

## Background

The backpressure counting feature switches the scan worker to a lightweight counting mode (emitting `'count'` messages) when the mapping queue is full. When backpressure drops, the scanner resumes normal feeding — but files discovered in normal mode only sent `'file'` messages, never `'count'`. The main thread's `totalDiscoveredFiles` stayed frozen at the last counting-mode value while `processedFiles` kept climbing.

## Implementation options considered

| Option | Approach | Pros | Cons |
|--------|----------|------|------|
| **A** | Increment `totalDiscoveredFiles` in the main thread's `'file'` handler | Minimal change (3 lines), no scan worker changes | Splits ownership of the count between scan worker and main thread. Fragile — future `'file'` handler changes could forget to increment. |
| **B** | Scan worker sends `'count'` with every `'file'` in normal mode | Single source of truth for count | Doubles message volume during normal feeding (~450K extra messages for large datasets) |
| **B-throttled** | Scan worker sends periodic `'count'` every N files in normal mode + final `'count'` before `'done'` | Single source of truth, negligible overhead (~2K extra messages for 230K files), consistent with existing counting-mode pattern | Up to N-1 files of transient staleness (acceptable for a progress indicator) |
| **C** | Scan worker sends a single final `'count'` before `'done'` | One extra message total | Progress bar stays wrong until scanning finishes — can be a long time for large datasets |

**Chosen: B-throttled (N=100)** — the scan worker is the sole authority on `totalDiscovered`. The main thread remains a passive consumer of `'count'` messages, same as before. The pattern is consistent with counting mode behavior. Maximum transient staleness is 99 files, which is negligible for datasets of any size.