### PR TITLE
feat: implement preExclude and postExclude feature in specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,56 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
 }
 ```
 
+## Filtering files with preFilter and postFilter
+
+The curation specification supports two optional filter functions that let you skip files at different stages of processing.
+
+### preFilter — skip before mapping
+
+`preFilter` receives a `parser` with access to the **original, unmapped DICOM tags**. Return `false` to skip the file entirely — it will not be mapped, written, or uploaded.
+
+```ts
+export function myCurationSpec(): TCurationSpecification {
+  return {
+    // ... other fields ...
+
+    // Only process files whose PatientID matches the expected study format.
+    preFilter(parser) {
+      return /^AB\d{2}-\d{3}$/.test(parser.getDicom('PatientID'))
+    },
+  }
+}
+```
+
+### postFilter — skip after mapping
+
+`postFilter` receives the **final output file path** and a `parser` whose `getDicom()` returns **de-identified tag values** (PS315E de-identification has already run at this point). Return `false` to skip writing or uploading the mapped file.
+
+```ts
+export function myCurationSpec(): TCurationSpecification {
+  return {
+    // ... other fields ...
+
+    // Skip structured reports and files routed to an 'exclude' output folder.
+    postFilter(outputFilePath, parser) {
+      if (parser.getDicom('Modality') === 'SR') return false
+      if (outputFilePath.includes('/exclude/')) return false
+      return true
+    },
+  }
+}
+```
+
+### Result shape
+
+When a file is skipped by either filter, `curateOne` / `curateMany` still returns a result object for it. The `filtered` field indicates which filter excluded it:
+
+```ts
+// 'pre'  — excluded by preFilter (file was never mapped)
+// 'post' — excluded by postFilter (file was mapped but not written)
+result.filtered // => 'pre' | 'post' | undefined
+```
+
 ## DICOM Conformance Notes
 
 dicom-curate

--- a/README.md
+++ b/README.md
@@ -287,54 +287,62 @@ export function sampleBatchCurationSpecification(): TCurationSpecification {
 }
 ```
 
-## Filtering files with preFilter and postFilter
+## Excluding files with preExclude and postExclude
 
-The curation specification supports two optional filter functions that let you skip files at different stages of processing.
+The curation specification supports two optional exclusion functions that let you skip files at different stages of processing. Both return **`true` to exclude** the file; returning `false` (or omitting the function entirely) lets the file through.
 
-### preFilter — skip before mapping
+### preExclude — skip before mapping
 
-`preFilter` receives a `parser` with access to the **original, unmapped DICOM tags**. Return `false` to skip the file entirely — it will not be mapped, written, or uploaded.
-
-```ts
-export function myCurationSpec(): TCurationSpecification {
-  return {
-    // ... other fields ...
-
-    // Only process files whose PatientID matches the expected study format.
-    preFilter(parser) {
-      return /^AB\d{2}-\d{3}$/.test(parser.getDicom('PatientID'))
-    },
-  }
-}
-```
-
-### postFilter — skip after mapping
-
-`postFilter` receives the **final output file path** and a `parser` whose `getDicom()` returns **de-identified tag values** (PS315E de-identification has already run at this point). Return `false` to skip writing or uploading the mapped file.
+`preExclude` receives a `parser` with access to the **original, unmapped DICOM tags**. Return `true` to skip the file entirely — it will not be mapped, written, or uploaded.
 
 ```ts
 export function myCurationSpec(): TCurationSpecification {
   return {
     // ... other fields ...
 
-    // Skip structured reports and files routed to an 'exclude' output folder.
-    postFilter(outputFilePath, parser) {
-      if (parser.getDicom('Modality') === 'SR') return false
-      if (outputFilePath.includes('/exclude/')) return false
-      return true
+    // Exclude files whose PatientID doesn't match the expected study format.
+    preExclude(parser) {
+      return !/^AB\d{2}-\d{3}$/.test(parser.getDicom('PatientID'))
     },
   }
 }
 ```
+
+### postExclude — skip after mapping
+
+`postExclude` receives a `parser` whose `getDicom()` returns **de-identified tag values** (PS315E de-identification has already run at this point), and exposes the computed output path as `parser.outputFilePath`. Return `true` to skip writing or uploading the mapped file.
+
+Note: `parser.getFilePathComp()` still returns **input** path components inside `postExclude`, the same as in `preExclude`. Only `parser.outputFilePath` reflects the post-mapping location, as a full string.
+
+```ts
+export function myCurationSpec(): TCurationSpecification {
+  return {
+    // ... other fields ...
+
+    // Exclude structured reports and files routed to an 'exclude' output folder.
+    postExclude(parser) {
+      if (parser.getDicom('Modality') === 'SR') return true
+      if (parser.outputFilePath.includes('/exclude/')) return true
+      return false
+    },
+  }
+}
+```
+
+### Behaviour notes
+
+- **Exclusions are re-evaluated on every run.** When a `preExclude` or `postExclude` is configured, the "unchanged source bytes" short-circuit is disabled so an exclusion added in a later run takes effect even if the file itself didn't change.
+- **Composition across multiple specs is OR.** When `composeSpecs` merges specs that each define `preExclude` / `postExclude`, the composed function excludes a file if **any** spec's function returns `true`. Evaluation short-circuits on the first `true`.
+- **Exceptions are fail-safe.** If an exclusion function throws, the file is treated as **included** and the error message is appended to `mapResults.errors`.
 
 ### Result shape
 
-When a file is skipped by either filter, `curateOne` / `curateMany` still returns a result object for it. The `filtered` field indicates which filter excluded it:
+When a file is excluded, `curateOne` / `curateMany` still returns a result object for it. The `excluded` field indicates which function rejected it:
 
 ```ts
-// 'pre'  — excluded by preFilter (file was never mapped)
-// 'post' — excluded by postFilter (file was mapped but not written)
-result.filtered // => 'pre' | 'post' | undefined
+// 'pre'  — excluded by preExclude (file was never mapped)
+// 'post' — excluded by postExclude (file was mapped but not written)
+result.excluded // => 'pre' | 'post' | undefined
 ```
 
 ## DICOM Conformance Notes

--- a/src/collectMappings.test.ts
+++ b/src/collectMappings.test.ts
@@ -1,7 +1,24 @@
 import * as dcmjs from 'dcmjs'
 import { sample } from '../testdata/sample'
 import collectMappings from './collectMappings'
-import type { TMappingOptions } from './types'
+import type { TCurationSpecification, TMappingOptions } from './types'
+
+// A minimal spec that maps input path 'study/subject/test.dcm' to the same
+// output path, so no filename replacement occurs and outputFilePath is predictable.
+function makeSpec(
+  overrides: Partial<TCurationSpecification> = {},
+): () => TCurationSpecification {
+  return () => ({
+    version: '3.0',
+    inputPathPattern: 'study/subject',
+    hostProps: {},
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: () => ['study', 'subject', 'test.dcm'],
+    errors: () => [],
+    ...overrides,
+  })
+}
 
 describe('collectMappings with none specification', () => {
   it('returns early with naturalized dataset and empty map results', () => {
@@ -41,5 +58,187 @@ describe('collectMappings with none specification', () => {
     expect(() =>
       collectMappings('input.dcm', sample, mappingOptions),
     ).not.toThrow()
+  })
+})
+
+describe('collectMappings preExclude', () => {
+  it('sets excluded: pre and returns early when preExclude returns true', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({ preExclude: () => true }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBe('pre')
+    expect(mapResults.mappings).toEqual({})
+    expect(mapResults.outputFilePath).toBe('')
+  })
+
+  it('continues normally when preExclude returns false', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({ preExclude: () => false }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBeUndefined()
+    expect(mapResults.outputFilePath).toBe('study/subject/test.dcm')
+  })
+
+  it('passes original DICOM tags to preExclude via parser.getDicom', () => {
+    let capturedPatientId: string | undefined
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        preExclude: (parser) => {
+          capturedPatientId = parser.getDicom('PatientID')
+          return false
+        },
+      }),
+    }
+
+    collectMappings('study/subject/test.dcm', sample, mappingOptions)
+
+    // sample has PatientID '00100020' → 'Test Long String'
+    expect(capturedPatientId).toBe('Test Long String')
+  })
+
+  it('does not call postExclude when preExclude returns true', () => {
+    const postExclude = vi.fn(() => false)
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({ preExclude: () => true, postExclude }),
+    }
+
+    collectMappings('study/subject/test.dcm', sample, mappingOptions)
+
+    expect(postExclude).not.toHaveBeenCalled()
+  })
+})
+
+describe('collectMappings postExclude', () => {
+  it('sets excluded: post and skips header mappings when postExclude returns true', () => {
+    const modifyDicomHeader = vi.fn(() => ({ PatientID: 'REPLACED' }))
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        postExclude: () => true,
+        modifyDicomHeader,
+      }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBe('post')
+    expect(mapResults.mappings).toEqual({})
+    expect(modifyDicomHeader).not.toHaveBeenCalled()
+  })
+
+  it('continues normally when postExclude returns false', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({ postExclude: () => false }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBeUndefined()
+  })
+
+  it('exposes the computed output file path via parser.outputFilePath', () => {
+    let capturedPath: string | undefined
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        outputFilePathComponents: () => ['out', 'dir', 'file.dcm'],
+        postExclude: (parser) => {
+          capturedPath = parser.outputFilePath
+          return false
+        },
+      }),
+    }
+
+    collectMappings('study/subject/test.dcm', sample, mappingOptions)
+
+    // When outputFilePath differs from inputFilePath, the filename segment is
+    // replaced with `${modality}_${uid}.dcm`; verify the directory prefix.
+    expect(capturedPath).toMatch(/^out\/dir\//)
+  })
+
+  it('exposes DICOM tags via parser.getDicom in postExclude', () => {
+    let capturedModality: string | undefined
+
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        postExclude: (parser) => {
+          capturedModality = parser.getDicom('Modality')
+          return false
+        },
+      }),
+    }
+
+    collectMappings('study/subject/test.dcm', sample, mappingOptions)
+
+    // sample has Modality '00080060' → 'TEST_CODE'
+    expect(capturedModality).toBe('TEST_CODE')
+  })
+})
+
+describe('collectMappings filter error handling', () => {
+  it('treats file as included and records error when preExclude throws', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        preExclude: () => {
+          throw new Error('boom in preExclude')
+        },
+      }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBeUndefined()
+    expect(mapResults.errors).toContain(
+      'preExclude threw an error: boom in preExclude — treating file as included (fail-safe)',
+    )
+  })
+
+  it('treats file as included and records error when postExclude throws', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: makeSpec({
+        postExclude: () => {
+          throw new Error('boom in postExclude')
+        },
+      }),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.excluded).toBeUndefined()
+    expect(mapResults.errors).toContain(
+      'postExclude threw an error: boom in postExclude — treating file as included (fail-safe)',
+    )
   })
 })

--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -48,12 +48,27 @@ export default function collectMappings(
     finalSpec.additionalData,
   )
 
+  // preExclude: original DICOM tags visible via parser.getDicom
+  let preExcludeError: string | undefined
+  try {
+    if (finalSpec.preExclude?.(parser)) {
+      mapResults.excluded = 'pre'
+      return [naturalData, mapResults]
+    }
+  } catch (e) {
+    preExcludeError = `preExclude threw an error: ${e instanceof Error ? e.message : String(e)} — treating file as included (fail-safe)`
+  }
+
   // List all validation errors
   if (!mappingOptions.skipValidation) {
     mapResults.errors = finalSpec
       .errors(parser)
       .filter(([, failure]) => failure)
       .map(([message]) => message)
+  }
+
+  if (preExcludeError) {
+    mapResults.errors.push(preExcludeError)
   }
 
   // Return listing for the "two-pass add mapping" scenario
@@ -135,6 +150,23 @@ export default function collectMappings(
         `${modality}_${mapResults.sourceInstanceUID}.dcm`
       mapResults.outputFilePath = parts.join('/')
     }
+  }
+
+  // postExclude: output path is finalised; parser.getDicom() returns de-identified values
+  try {
+    if (
+      finalSpec.postExclude?.({
+        ...parser,
+        outputFilePath: mapResults.outputFilePath,
+      })
+    ) {
+      mapResults.excluded = 'post'
+      return [naturalData, mapResults]
+    }
+  } catch (e) {
+    mapResults.errors.push(
+      `postExclude threw an error: ${e instanceof Error ? e.message : String(e)} — treating file as included (fail-safe)`,
+    )
   }
 
   // Moving this after collectMappingsInData as this should take precedence.

--- a/src/composeSpecs.test.ts
+++ b/src/composeSpecs.test.ts
@@ -3,7 +3,12 @@ import { composeSpecs } from './composeSpecs'
 import { sample2PassCurationSpecification } from './config/sample2PassCurationSpecification'
 import { sampleBatchCurationSpecification } from './config/sampleBatchCurationSpecification'
 import curateDict from './curateDict'
-import type { TCurationSpecification, TMappingOptions, TParser } from './types'
+import type {
+  TCurationSpecification,
+  TMappingOptions,
+  TParser,
+  TPostExcludeParser,
+} from './types'
 
 // Helper function to create equivalent composite spec from batch spec
 function createEquivalentCompositeSpecFromBatch(): () => TCurationSpecification {
@@ -274,6 +279,139 @@ describe('composeSpecs equivalence tests', () => {
       'base',
       'output',
     ])
+  })
+
+  describe('preExclude and postExclude composition', () => {
+    const mockParser = {} as Partial<TParser> as TParser
+    const mockPostParser = {
+      outputFilePath: '/out/file.dcm',
+    } as Partial<TPostExcludeParser> as TPostExcludeParser
+
+    it('preExclude is undefined when no spec defines it', () => {
+      const composed = composeSpecs({ version: '3.0' })
+      expect(composed.preExclude).toBeUndefined()
+    })
+
+    it('postExclude is undefined when no spec defines it', () => {
+      const composed = composeSpecs({ version: '3.0' })
+      expect(composed.postExclude).toBeUndefined()
+    })
+
+    it('preExclude from single spec is preserved as-is', () => {
+      const filter = vi.fn().mockReturnValue(true)
+      const composed = composeSpecs({ version: '3.0', preExclude: filter })
+      expect(composed.preExclude!(mockParser)).toBe(true)
+      expect(filter).toHaveBeenCalledWith(mockParser)
+    })
+
+    it('postExclude from single spec is preserved as-is', () => {
+      const filter = vi.fn().mockReturnValue(true)
+      const composed = composeSpecs({ version: '3.0', postExclude: filter })
+      expect(composed.postExclude!(mockPostParser)).toBe(true)
+      expect(filter).toHaveBeenCalledWith(mockPostParser)
+    })
+
+    it('preExclude: any spec returning true causes exclusion (logical OR)', () => {
+      const spec1 = { version: '3.0', preExclude: () => false }
+      const spec2 = { version: '3.0', preExclude: () => true }
+      const spec3 = { version: '3.0', preExclude: () => false }
+      const composed = composeSpecs([spec1, spec2, spec3])
+      expect(composed.preExclude!(mockParser)).toBe(true)
+    })
+
+    it('preExclude: all returning false does not exclude', () => {
+      const spec1 = { version: '3.0', preExclude: () => false }
+      const spec2 = { version: '3.0', preExclude: () => false }
+      const composed = composeSpecs([spec1, spec2])
+      expect(composed.preExclude!(mockParser)).toBe(false)
+    })
+
+    it('postExclude: any spec returning true causes exclusion (logical OR)', () => {
+      const spec1 = { version: '3.0', postExclude: () => false }
+      const spec2 = { version: '3.0', postExclude: () => true }
+      const composed = composeSpecs([spec1, spec2])
+      expect(composed.postExclude!(mockPostParser)).toBe(true)
+    })
+
+    it('preExclude: short-circuits on first true — subsequent filters not called', () => {
+      const first = vi.fn().mockReturnValue(true)
+      const second = vi.fn().mockReturnValue(false)
+      const composed = composeSpecs([
+        { version: '3.0', preExclude: first },
+        { version: '3.0', preExclude: second },
+      ])
+      composed.preExclude!(mockParser)
+      expect(first).toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+    })
+
+    it('postExclude: short-circuits on first true — subsequent filters not called', () => {
+      const first = vi.fn().mockReturnValue(true)
+      const second = vi.fn().mockReturnValue(false)
+      const composed = composeSpecs([
+        { version: '3.0', postExclude: first },
+        { version: '3.0', postExclude: second },
+      ])
+      composed.postExclude!(mockPostParser)
+      expect(first).toHaveBeenCalled()
+      expect(second).not.toHaveBeenCalled()
+    })
+
+    it('preExclude: spec with filter + spec without → filter still applied', () => {
+      const filter = vi.fn().mockReturnValue(true)
+      const composed = composeSpecs([
+        { version: '3.0', preExclude: filter },
+        { version: '3.0' },
+      ])
+      expect(composed.preExclude!(mockParser)).toBe(true)
+      expect(filter).toHaveBeenCalledOnce()
+    })
+
+    it('postExclude: spec without filter + spec with filter → filter still applied', () => {
+      const filter = vi.fn().mockReturnValue(true)
+      const composed = composeSpecs([
+        { version: '3.0' },
+        { version: '3.0', postExclude: filter },
+      ])
+      expect(composed.postExclude!(mockPostParser)).toBe(true)
+      expect(filter).toHaveBeenCalledOnce()
+    })
+
+    it('preExclude: filters applied in input order', () => {
+      const callOrder: number[] = []
+      const first = vi.fn().mockImplementation(() => {
+        callOrder.push(1)
+        return false
+      })
+      const second = vi.fn().mockImplementation(() => {
+        callOrder.push(2)
+        return false
+      })
+      const composed = composeSpecs([
+        { version: '3.0', preExclude: first },
+        { version: '3.0', preExclude: second },
+      ])
+      composed.preExclude!(mockParser)
+      expect(callOrder).toEqual([1, 2])
+    })
+
+    it('postExclude: filters applied in input order', () => {
+      const callOrder: number[] = []
+      const first = vi.fn().mockImplementation(() => {
+        callOrder.push(1)
+        return false
+      })
+      const second = vi.fn().mockImplementation(() => {
+        callOrder.push(2)
+        return false
+      })
+      const composed = composeSpecs([
+        { version: '3.0', postExclude: first },
+        { version: '3.0', postExclude: second },
+      ])
+      composed.postExclude!(mockPostParser)
+      expect(callOrder).toEqual([1, 2])
+    })
   })
 
   it('composeSpecs validates version consistency', () => {

--- a/src/composeSpecs.ts
+++ b/src/composeSpecs.ts
@@ -6,6 +6,7 @@ import type {
   HostProps,
   TCurationSpecification,
   TParser,
+  TPostExcludeParser,
   TPs315Options,
 } from '../src/types'
 import { defaultSpec } from './defaultSpec'
@@ -238,6 +239,22 @@ export function composeSpecs(
       final.errors = (p: TParser) => {
         return [...prev(p), ...next(p)]
       }
+    }
+
+    // preExclude: exclude if any excluder returns true (logical OR)
+    if (spec.preExclude) {
+      const prev = final.preExclude
+      const next = spec.preExclude
+      final.preExclude = prev ? (p) => prev(p) || next(p) : next
+    }
+
+    // postExclude: exclude if any excluder returns true (logical OR)
+    if (spec.postExclude) {
+      const prev = final.postExclude
+      const next = spec.postExclude
+      final.postExclude = prev
+        ? (p: TPostExcludeParser) => prev(p) || next(p)
+        : next
     }
   }
 

--- a/src/curateOne.test.ts
+++ b/src/curateOne.test.ts
@@ -254,6 +254,268 @@ describe('curateOne skip paths', () => {
   })
 })
 
+describe('curateOne preExclude and postExclude', () => {
+  const inputPath =
+    'Sample_Protocol_Number/Sample_CRO/AB12-123/Visit 1/PET-Abdomen'
+
+  function buildDicomBuffer(patientId = 'AB12-123') {
+    const dataset = {
+      PatientName: patientId,
+      PatientID: patientId,
+      Modality: 'CT',
+      SOPClassUID: '1.2.840.10008.5.1.4.1.1.2',
+      SOPInstanceUID: '1.2.3.4.5.6.7.8.9',
+      SeriesInstanceUID: '1.2.3.4.5.6.7.8',
+      StudyInstanceUID: '1.2.3.4.5.6.7',
+      SeriesNumber: '1',
+    }
+    const dicomDict = new dcmjs.data.DicomDict({
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+      '00020002': { vr: 'UI', Value: [dataset.SOPClassUID] },
+      '00020003': { vr: 'UI', Value: [dataset.SOPInstanceUID] },
+    })
+    dicomDict.dict = dcmjs.data.DicomMetaDictionary.denaturalizeDataset(dataset)
+    return dicomDict.write({ allowInvalidVRLength: true })
+  }
+
+  function makeSpec(
+    overrides: Partial<TCurationSpecification> = {},
+  ): () => TCurationSpecification {
+    return () => ({
+      inputPathPattern:
+        'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+      version: '3.0',
+      hostProps: {},
+      dicomPS315EOptions: 'Off',
+      modifyDicomHeader: () => ({}),
+      outputFilePathComponents: (parser) => [
+        parser.getFilePathComp('protocolNumber'),
+        parser.getFilePathComp('activityProvider'),
+        parser.getFilePathComp(parser.FILENAME),
+      ],
+      errors: () => [],
+      ...overrides,
+    })
+  }
+
+  it('returns excluded: pre and skips write when preExclude returns true', async () => {
+    const buffer = buildDicomBuffer()
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({ preExclude: () => true }),
+        skipWrite: false,
+      },
+    })
+
+    expect(result.excluded).toBe('pre')
+    expect(result.mappedBlob).toBeUndefined()
+    expect(result.fileInfo).toBeDefined()
+    expect(result.fileInfo!.name).toBe('test.dcm')
+    expect(result.fileInfo!.size).toBe(buffer.byteLength)
+  })
+
+  it('returns excluded: post and skips write when postExclude returns true', async () => {
+    const buffer = buildDicomBuffer()
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({ postExclude: () => true }),
+        skipWrite: false,
+      },
+    })
+
+    expect(result.excluded).toBe('post')
+    expect(result.mappedBlob).toBeUndefined()
+    expect(result.fileInfo).toBeDefined()
+    expect(result.fileInfo!.name).toBe('test.dcm')
+  })
+
+  it('processes normally when preExclude returns false', async () => {
+    const buffer = buildDicomBuffer()
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({ preExclude: () => false }),
+        skipWrite: false,
+      },
+    })
+
+    expect(result.excluded).toBeUndefined()
+    expect(result.mappedBlob).toBeDefined()
+    expect(result.mappingRequired).toBe(true)
+  })
+
+  it('passes original PatientID to preExclude before any mapping', async () => {
+    const buffer = buildDicomBuffer('ORIGINAL_ID')
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    let capturedId: string | undefined
+
+    await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({
+          preExclude: (parser) => {
+            capturedId = parser.getDicom('PatientID')
+            return false
+          },
+          // modifyDicomHeader replaces PatientID — preExclude must see the original
+          modifyDicomHeader: () => ({ PatientID: 'REPLACED' }),
+        }),
+        skipWrite: false,
+      },
+    })
+
+    expect(capturedId).toBe('ORIGINAL_ID')
+  })
+
+  it('passes computed output file path to postExclude', async () => {
+    const buffer = buildDicomBuffer()
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    let capturedPath: string | undefined
+
+    await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({
+          outputFilePathComponents: () => ['out', 'subdir', 'result.dcm'],
+          postExclude: (parser) => {
+            capturedPath = parser.outputFilePath
+            return false
+          },
+        }),
+        skipWrite: false,
+      },
+    })
+
+    expect(capturedPath).toContain('out/subdir/')
+  })
+
+  it('does not upload when postExclude excludes the file', async () => {
+    const buffer = buildDicomBuffer()
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const mockFetch = vi.fn<typeof fetch>()
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch
+
+    try {
+      const result = await curateOne({
+        fileInfo,
+        outputTarget: { http: { url: 'https://example.com/upload' } },
+        mappingOptions: {
+          curationSpec: makeSpec({ postExclude: () => true }),
+          skipWrite: false,
+        },
+      })
+
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(result.excluded).toBe('post')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('evaluates preExclude even when previousSourceFileInfo hash matches', async () => {
+    const buffer = buildDicomBuffer()
+    const preMappedHash = await hash(buffer, 'md5')
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({ preExclude: () => true }),
+        skipWrite: false,
+      },
+      hashMethod: 'md5',
+      previousSourceFileInfo: { preMappedHash },
+    })
+
+    expect(result.excluded).toBe('pre')
+  })
+
+  it('evaluates postExclude even when previousSourceFileInfo hash matches', async () => {
+    const buffer = buildDicomBuffer()
+    const preMappedHash = await hash(buffer, 'md5')
+    const fileInfo: TFileInfo = {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+
+    const result = await curateOne({
+      fileInfo,
+      outputTarget: {},
+      mappingOptions: {
+        curationSpec: makeSpec({ postExclude: () => true }),
+        skipWrite: false,
+      },
+      hashMethod: 'md5',
+      previousSourceFileInfo: { preMappedHash },
+    })
+
+    expect(result.excluded).toBe('post')
+  })
+})
+
 describe('curateOne upload ETag capture', () => {
   const noOpSpec: () => TCurationSpecification = () => ({
     inputPathPattern:

--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -1,4 +1,5 @@
 import * as dcmjs from 'dcmjs'
+import { composeSpecs } from './composeSpecs'
 import createNestedDirectories from './createNestedDirectories'
 import curateDict from './curateDict'
 import { fetchWithRetry } from './fetchWithRetry'
@@ -39,6 +40,12 @@ export type TCurateOneArgs = {
       }
     | undefined
   >
+}
+
+function specHasFilter(mappingOptions: TMappingOptions): boolean {
+  if (mappingOptions.curationSpec === 'none') return false
+  const composed = composeSpecs(mappingOptions.curationSpec())
+  return !!(composed.preExclude ?? composed.postExclude)
 }
 
 export async function curateOne({
@@ -238,7 +245,9 @@ export async function curateOne({
     return retval
   }
 
-  if (canSkip && previousSourceFileInfo) {
+  const hasFilter = specHasFilter(mappingOptions)
+
+  if (canSkip && previousSourceFileInfo && !hasFilter) {
     return noMapResult()
   }
 
@@ -292,6 +301,20 @@ export async function curateOne({
       mappedDicomData = {
         write: () => fileArrayBuffer!,
       }
+    }
+
+    // File excluded by preExclude or postExclude — skip write and return immediately.
+    if (clonedMapResults.excluded) {
+      clonedMapResults.mappingRequired = false
+      clonedMapResults.fileInfo = {
+        name: fileInfo.name,
+        size: fileInfo.size,
+        path: fileInfo.path,
+        mtime,
+        preMappedHash,
+      }
+      clonedMapResults.curationTime = performance.now() - startTime
+      return clonedMapResults
     }
 
     // Indicate that mapping was required (we didn't hit the early-skip branch above)

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,9 @@ export type TMapResults = {
   // New semantics: mappingRequired indicates that mapping must be applied.
   // This replaces the old `noMappingRequired` flag (inverted semantics).
   mappingRequired?: boolean
+  // Set when the file was excluded by a preExclude or postExclude in the curation spec.
+  // 'pre': excluded before mapping (original tags); 'post': excluded after output path computed.
+  excluded?: 'pre' | 'post'
   // Time in ms for curation logic
   curationTime?: number
 }
@@ -249,6 +252,13 @@ export type TParser = {
   addDays: (dicomDateString: string, offsetDays: number) => string
   FILENAME: symbol
   FILEBASENAME: symbol
+}
+
+// Parser passed to postExclude — same as TParser but with the computed output path attached.
+// Use parser.outputFilePath to access the output path; parser.getFilePathComp() still
+// returns input path components (as in preExclude).
+export type TPostExcludeParser = TParser & {
+  outputFilePath: string
 }
 
 type TMappingInputDirect = {
@@ -302,6 +312,20 @@ export type TCurationSpecification<THost extends HostProps = HostProps> = {
     | TMappingInputTwoPass
   )
   excludedFiletypes?: string[]
+  // Called with original (pre-mapping) DICOM tags. Return true to exclude (skip) the file.
+  //
+  // Example — skip files whose Patient ID doesn't match the expected format:
+  //   preExclude: (parser) => !/^AB\d{2}-\d{3}$/.test(parser.getDicom('PatientID')),
+  preExclude?: (parser: TParser) => boolean
+  // Called after the output path is computed and PS315E de-identification has run.
+  // parser.getDicom() returns de-identified tag values at this point.
+  // Use parser.outputFilePath to access the computed output path.
+  // Return true to exclude (skip) writing/uploading the file.
+  //
+  // Example — skip files mapped into an 'exclude' output folder, or with an unwanted modality:
+  //   postExclude: (parser) =>
+  //     parser.outputFilePath.includes('/exclude/') || parser.getDicom('Modality') === 'SR',
+  postExclude?: (parser: TPostExcludeParser) => boolean
 }
 
 type TProgressMessageBase = {


### PR DESCRIPTION
Tested with MedEx by adding filters such as:

```
preExclude(parser) {
    return parser.getDicom('PatientID') === '09J4HLBKP';
},
```
or
```
postExclude(parser) {
    return parser.getDicom('StationName') === 'MTRADSPCT31';
},
```
