### PR TITLE
feat: custom uploader interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,49 @@ It is also possible to use S3-compatible buckets as input or output locations.
 Consult `OrganizeOptions` for further details. Please note that this feature is only
 available if you have the `@aws-sdk/client-s3` package installed.
 
+### Custom uploader
+
+For use cases that require resumable, chunked, or otherwise non-standard uploads, you can supply your own uploader via `outputUploader`. This is mutually exclusive with `outputEndpoint`.
+
+The uploader runs on the **main thread**. When using `curateMany()`, the mapped file's `ReadableStream` is transferred directly from the worker to the main thread (zero-copy) and handed as-is to the uploader.
+
+```ts
+import { curateMany, OrganizeOptions, TCustomUploader } from 'dicom-curate'
+
+const myUploader: TCustomUploader = {
+  async upload({ key, stream, size, contentType, headers, signal }) {
+    // key      – output path relative to the root (URL-encoded path segments)
+    // stream   – ReadableStream<Uint8Array> of the mapped DICOM bytes; consume once
+    // size     – total byte length of the file
+    // headers  – derived metadata headers (X-File-*, x-source-file-hash, …)
+    // signal   – AbortSignal forwarded from OrganizeOptions.signal
+
+    const response = await fetch(`https://my-server.example.com/upload/${key}`, {
+      method: 'PUT',
+      body: stream,
+      headers: { 'Content-Length': String(size), ...headers },
+      signal,
+      // @ts-expect-error – duplex required by some runtimes for streaming bodies
+      duplex: 'half',
+    })
+
+    const etag = response.headers.get('ETag') ?? undefined
+    return { etag }
+  },
+}
+
+const options: OrganizeOptions = {
+  inputType: 'path',
+  inputDirectory: '/home/user/files',
+  outputUploader: myUploader,
+  curationSpec,
+}
+
+await curateMany(files, options)
+```
+
+The value returned by `upload()` is passed back through the `CurateResult` for each file, so you can store server-assigned identifiers (e.g. ETags, upload IDs) alongside the normal curation results.
+
 ### Matching S3 ETags across uploaders
 
 When uploading to S3, you can set `uploadPartSize` on the output S3
@@ -191,6 +234,29 @@ const columnMappings = extractColumnMappings([
 curateOne({
   fileInfo, // path, name, size, kind, blob
   mappingOptions: { curationSpec, columnMappings },
+})
+```
+
+To use a custom uploader with `curateOne`, set `outputTarget.custom: true` and provide an `uploader` function directly on the call arguments:
+
+```ts
+import { curateOne } from 'dicom-curate'
+
+const result = await curateOne({
+  fileInfo,
+  mappingOptions: { curationSpec },
+  outputTarget: { custom: true },
+  uploader: async ({ key, stream, size, headers, signal }) => {
+    const response = await fetch(`https://my-server.example.com/upload/${key}`, {
+      method: 'PUT',
+      body: stream,
+      headers: { 'Content-Length': String(size), ...headers },
+      signal,
+      // @ts-expect-error – duplex required by some runtimes for streaming bodies
+      duplex: 'half',
+    })
+    return { etag: response.headers.get('ETag') ?? undefined }
+  },
 })
 ```
 

--- a/src/applyMappingsWorker.ts
+++ b/src/applyMappingsWorker.ts
@@ -28,12 +28,24 @@ export type LookupResponse = {
   postMappedHash?: string
 }
 
+/** Response sent from the main thread when a custom upload succeeds. */
+export type UploadResult = {
+  response: 'uploadResult'
+  etag?: string
+}
+
+/** Response sent from the main thread when a custom upload fails. */
+export type UploadError = {
+  response: 'uploadError'
+  error: string
+}
+
 /**
  * Safely serialize an error for postMessage to avoid DataCloneError.
  * Some error objects contain non-cloneable properties (circular references,
  * native handles, etc.) that cause postMessage to throw.
  */
-function safeSerializeError(error: unknown): string {
+export function safeSerializeError(error: unknown): string {
   if (error instanceof Error) {
     return `${error.name}: ${error.message}`
   }
@@ -95,11 +107,53 @@ function lookupMappedFileInfo(
   })
 }
 
+// Pending resolve/reject for an in-flight custom upload round-trip.
+// Safe as singletons because the pool dispatches at most one file per worker
+// at a time, so only one upload is ever in flight per worker instance.
+let pendingUploadResolve: ((r: { etag?: string }) => void) | null = null
+let pendingUploadReject: ((e: unknown) => void) | null = null
+
+/**
+ * Proxy a custom upload through the main thread. Transfers the ReadableStream
+ * directly (zero-copy, no materialisation) so the main thread can hand it
+ * as-is to the user-supplied TCustomUploader.
+ */
+function uploadViaMain(args: {
+  key: string
+  stream: ReadableStream<Uint8Array>
+  size: number
+  contentType?: string
+  headers?: Record<string, string>
+}): Promise<{ etag?: string }> {
+  return new Promise((resolve, reject) => {
+    pendingUploadResolve = resolve
+    pendingUploadReject = reject
+    // Cast to any: in a worker context postMessage accepts a transfer list as
+    // the second argument, but TypeScript's lib.dom.d.ts types globalThis
+    // postMessage with Window's signature which doesn't allow that form.
+    globalThis.postMessage(
+      {
+        response: 'upload',
+        key: args.key,
+        stream: args.stream,
+        size: args.size,
+        contentType: args.contentType,
+        headers: args.headers,
+      },
+      [args.stream] as any,
+    )
+  })
+}
+
 fixupNodeWorkerEnvironment()
   .then(() => {
     globalThis.addEventListener(
       'message',
-      (event: MessageEvent<MappingRequest | LookupResponse>) => {
+      (
+        event: MessageEvent<
+          MappingRequest | LookupResponse | UploadResult | UploadError
+        >,
+      ) => {
         // Handle lookup response from main thread
         if (
           'response' in event.data &&
@@ -111,6 +165,25 @@ fixupNodeWorkerEnvironment()
             const hash = (event.data as LookupResponse).postMappedHash
             resolve(hash ? { postMappedHash: hash } : undefined)
           }
+          return
+        }
+
+        // Handle custom upload result/error from main thread
+        if (
+          'response' in event.data &&
+          event.data.response === 'uploadResult'
+        ) {
+          const resolve = pendingUploadResolve
+          pendingUploadResolve = null
+          pendingUploadReject = null
+          resolve?.({ etag: event.data.etag })
+          return
+        }
+        if ('response' in event.data && event.data.response === 'uploadError') {
+          const reject = pendingUploadReject
+          pendingUploadResolve = null
+          pendingUploadReject = null
+          reject?.(new Error(event.data.error))
           return
         }
 
@@ -137,6 +210,9 @@ fixupNodeWorkerEnvironment()
             mappingOptions,
             previousSourceFileInfo: data.previousFileInfo,
             previousMappedFileInfo: lookupMappedFileInfo,
+            // We execute the custom uploader on the main thread.
+            // The "custom" flag is just an indicator that the uploader function is provided.
+            uploader: data.outputTarget?.custom ? uploadViaMain : undefined,
           })
             .then((mapResults) => {
               // Send finished message for completion

--- a/src/curateMany.test.ts
+++ b/src/curateMany.test.ts
@@ -51,6 +51,8 @@ describe('curateMany', () => {
       markScanPaused: vi.fn(),
       scanAnomalies: [],
       setDirectoryScanFinished: vi.fn(),
+      setAbortSignal: vi.fn(),
+      setCustomUploader: vi.fn(),
       setMappingWorkerOptions: vi.fn(),
       setScanResumeCallback: vi.fn(),
       setTotalDiscoveredFiles: vi.fn(),

--- a/src/curateOne.test.ts
+++ b/src/curateOne.test.ts
@@ -979,3 +979,151 @@ describe('curateOne S3 output upload strategy', () => {
     expect(result.uploadErrors![0]).toContain('network blew up')
   })
 })
+
+describe('curateOne custom uploader', () => {
+  const noOpSpec: () => TCurationSpecification = () => ({
+    inputPathPattern:
+      'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+    version: '3.0',
+    hostProps: {},
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: (parser) => [
+      parser.getFilePathComp('protocolNumber'),
+      parser.getFilePathComp('activityProvider'),
+      parser.getFilePathComp(parser.FILENAME),
+    ],
+    errors: () => [],
+  })
+
+  const inputPath =
+    'Sample_Protocol_Number/Sample_CRO/AB12-123/Visit 1/PET-Abdomen'
+
+  function buildDicomBuffer() {
+    const dataset = {
+      PatientName: 'Test',
+      PatientID: 'P001',
+      Modality: 'CT',
+      SOPClassUID: '1.2.840.10008.5.1.4.1.1.2',
+      SOPInstanceUID: '1.2.3.4.5.6.7.8.9',
+      SeriesInstanceUID: '1.2.3.4.5.6.7.8',
+      StudyInstanceUID: '1.2.3.4.5.6.7',
+      SeriesNumber: '1',
+    }
+    const dicomDict = new dcmjs.data.DicomDict({
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+      '00020002': { vr: 'UI', Value: [dataset.SOPClassUID] },
+      '00020003': { vr: 'UI', Value: [dataset.SOPInstanceUID] },
+    })
+    dicomDict.dict = dcmjs.data.DicomMetaDictionary.denaturalizeDataset(dataset)
+    return dicomDict.write({ allowInvalidVRLength: true })
+  }
+
+  function makeFileInfo(buffer: ArrayBuffer): TFileInfo {
+    return {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name: 'test.dcm',
+      size: buffer.byteLength,
+    }
+  }
+
+  it('throws when outputTarget.custom is set but no uploader is provided', async () => {
+    const buffer = buildDicomBuffer()
+    await expect(
+      curateOne({
+        fileInfo: makeFileInfo(buffer),
+        outputTarget: { custom: true },
+        mappingOptions: { curationSpec: noOpSpec, skipWrite: false },
+      }),
+    ).rejects.toThrow('no uploader was provided')
+  })
+
+  it('calls uploader with correct args and captures etag', async () => {
+    const buffer = buildDicomBuffer()
+    const mockEtag = '"abc123"'
+    const uploader = vi
+      .fn<
+        (args: {
+          key: string
+          stream: ReadableStream<Uint8Array>
+          size: number
+          contentType?: string
+          headers?: Record<string, string>
+          signal?: AbortSignal
+        }) => Promise<{ etag?: string }>
+      >()
+      .mockResolvedValue({ etag: mockEtag })
+
+    const result = await curateOne({
+      fileInfo: makeFileInfo(buffer),
+      outputTarget: { custom: true },
+      mappingOptions: { curationSpec: noOpSpec, skipWrite: false },
+      uploader,
+    })
+
+    expect(uploader).toHaveBeenCalledOnce()
+    const args = uploader.mock.calls[0][0]
+    expect(args.key).toMatch(/^Sample_Protocol_Number/)
+    expect(args.headers?.['x-source-file-hash']).toBeDefined()
+    expect(result.outputUpload?.etag).toBe(mockEtag)
+  })
+
+  it('forwards signal to the uploader', async () => {
+    const buffer = buildDicomBuffer()
+    const controller = new AbortController()
+    const uploader = vi
+      .fn<
+        (args: {
+          key: string
+          stream: ReadableStream<Uint8Array>
+          size: number
+          contentType?: string
+          headers?: Record<string, string>
+          signal?: AbortSignal
+        }) => Promise<{ etag?: string }>
+      >()
+      .mockResolvedValue({})
+
+    await curateOne({
+      fileInfo: makeFileInfo(buffer),
+      outputTarget: { custom: true },
+      mappingOptions: { curationSpec: noOpSpec, skipWrite: false },
+      uploader,
+      signal: controller.signal,
+    })
+
+    expect(uploader.mock.calls[0][0].signal).toBe(controller.signal)
+  })
+
+  it('uses distinct header keys for pre- and post-mapped hashes', async () => {
+    const buffer = buildDicomBuffer()
+    let capturedHeaders: Record<string, string> | undefined
+
+    await curateOne({
+      fileInfo: makeFileInfo(buffer),
+      outputTarget: { custom: true },
+      mappingOptions: { curationSpec: noOpSpec, skipWrite: false },
+      uploader: async ({ headers }) => {
+        capturedHeaders = headers
+        return {}
+      },
+      hashMethod: 'md5',
+    })
+
+    expect(capturedHeaders).toBeDefined()
+    // Pre-mapped hash is always sent under x-source-file-hash.
+    // Post-mapped hash, when present, uses a distinct key so there is no collision.
+    expect('x-source-file-hash' in capturedHeaders!).toBe(true)
+    const allKeys = Object.keys(capturedHeaders!)
+    const hashKeys = allKeys.filter(
+      (k) => k.includes('source-file') && k.includes('hash'),
+    )
+    // No duplicate keys (JS objects can't have duplicates, but verify the right names are used)
+    expect(new Set(hashKeys).size).toBe(hashKeys.length)
+    if ('x-source-file-post-mapped-hash' in capturedHeaders!) {
+      expect('x-source-file-post-mapped-hash').not.toBe('x-source-file-hash')
+    }
+  })
+})

--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -1,16 +1,16 @@
 import * as dcmjs from 'dcmjs'
-import { composeSpecs } from './composeSpecs'
 import {
   cancellableReadableStreamIterable,
   LazyCompositeBlob,
   LazyFileBlob,
   readableStreamToAsyncIterable,
 } from './blobUtil'
+import { composeSpecs } from './composeSpecs'
 import createNestedDirectories from './createNestedDirectories'
 import curateDict from './curateDict'
 import { fetchWithRetry } from './fetchWithRetry'
-import { loadLibStorage } from './libStorage'
 import { hash, hashStream } from './hash'
+import { loadLibStorage } from './libStorage'
 import { loadS3Client } from './s3Client'
 import type {
   TFileInfo,
@@ -47,6 +47,22 @@ export type TCurateOneArgs = {
       }
     | undefined
   >
+  /**
+   * Custom upload handler. When outputTarget.custom is set this must be
+   * provided. Receives the mapped file as a ReadableStream; consume it exactly
+   * once. The worker-side adapter (uploadViaMain) transfers the ReadableStream
+   * directly to the main thread as a transferable object.
+   */
+  uploader?: (args: {
+    key: string
+    stream: ReadableStream<Uint8Array>
+    size: number
+    contentType?: string
+    headers?: Record<string, string>
+    signal?: AbortSignal
+  }) => Promise<{ etag?: string }>
+  /** AbortSignal forwarded to the custom uploader so it can cancel in-flight requests. */
+  signal?: AbortSignal
 }
 
 function specHasFilter(mappingOptions: TMappingOptions): boolean {
@@ -63,6 +79,8 @@ export async function curateOne({
   hashPartSize,
   previousSourceFileInfo,
   previousMappedFileInfo,
+  uploader,
+  signal,
 }: TCurateOneArgs): Promise<
   // anomalies is minimally present.
   Omit<Partial<TMapResults>, 'anomalies'> & {
@@ -483,12 +501,16 @@ export async function curateOne({
         ),
         createWriteStream(fullFilePath),
       )
-    } else if (!outputTarget?.http && !outputTarget?.s3) {
+    } else if (
+      !outputTarget?.http &&
+      !outputTarget?.s3 &&
+      !outputTarget?.custom
+    ) {
       // Only create mappedBlob when there is no output target at all (no
-      // directory, no HTTP endpoint, no S3 bucket). When an upload target is
-      // present the blob has already been consumed and keeping it around
-      // retains the full file content in memory for every processed file,
-      // causing OOM crashes at scale.
+      // directory, no HTTP endpoint, no S3 bucket, no custom uploader). When
+      // an upload target is present the blob has already been consumed and
+      // keeping it around retains the full file content in memory for every
+      // processed file, causing OOM crashes at scale.
       clonedMapResults.mappedBlob = modifiedBlob
     }
 
@@ -616,6 +638,49 @@ export async function curateOne({
         clonedMapResults.uploadErrors = clonedMapResults.uploadErrors ?? []
         clonedMapResults.uploadErrors.push(
           `S3 Upload error: ${e instanceof Error ? e.message : String(e)}`,
+        )
+      }
+    } else if (outputTarget?.custom && !uploader) {
+      throw new Error(
+        'outputTarget.custom is set but no uploader was provided to curateOne',
+      )
+    } else if (outputTarget?.custom && uploader) {
+      try {
+        const key = clonedMapResults
+          .outputFilePath!.split('/')
+          .map(encodeURIComponent)
+          .join('/')
+
+        const headers: Record<string, string> = {
+          'Content-Type': modifiedBlob.type || 'application/octet-stream',
+          'X-File-Name': fileName,
+          'X-File-Size': String(modifiedBlob.size),
+          'X-Source-File-Size': String(clonedMapResults.fileInfo?.size ?? ''),
+          'X-Source-File-Modified-Time': mtime ?? '',
+          'x-source-file-hash': preMappedHash ?? '',
+        }
+        if (postMappedHash)
+          headers['x-source-file-post-mapped-hash'] = postMappedHash
+
+        const result = await uploader({
+          key,
+          stream: modifiedBlob.stream() as ReadableStream<Uint8Array>,
+          size: modifiedBlob.size,
+          contentType: modifiedBlob.type || 'application/octet-stream',
+          headers,
+          signal,
+        })
+
+        clonedMapResults.outputUpload = {
+          url: key,
+          status: 200,
+          etag: result.etag,
+        }
+      } catch (e) {
+        console.error('Custom upload error', e)
+        clonedMapResults.uploadErrors = clonedMapResults.uploadErrors ?? []
+        clonedMapResults.uploadErrors.push(
+          `Custom upload error: ${e instanceof Error ? e.message : String(e)}`,
         )
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import {
   markScanPaused,
   type ProgressCallback,
   scanAnomalies,
+  setAbortSignal,
+  setCustomUploader,
   setDirectoryScanFinished,
   setMappingWorkerOptions,
   setScanResumeCallback,
@@ -43,6 +45,7 @@ export type { ProgressCallback } from './mappingWorkerPool'
 export type {
   OrganizeOptions,
   TCurationSpecification,
+  TCustomUploader,
   TMapResults,
   TProgressMessage,
   TPs315Options,
@@ -163,8 +166,16 @@ async function collectMappingOptions(
   // first, get the folder mappings and set output directory
   //
 
+  if (organizeOptions.outputUploader && organizeOptions.outputEndpoint) {
+    throw new Error(
+      'outputUploader and outputEndpoint are mutually exclusive — provide one or the other.',
+    )
+  }
+
   const outputTarget: TMappingWorkerOptions['outputTarget'] = {}
-  if (organizeOptions.outputEndpoint) {
+  if (organizeOptions.outputUploader) {
+    outputTarget.custom = true
+  } else if (organizeOptions.outputEndpoint) {
     if ('bucketName' in organizeOptions.outputEndpoint) {
       outputTarget.s3 = organizeOptions.outputEndpoint
     } else {
@@ -385,6 +396,8 @@ async function curateMany(
             organizeOptions,
           )) as TMappingWorkerOptions,
         )
+        setCustomUploader(organizeOptions.outputUploader)
+        setAbortSignal(organizeOptions.signal)
 
         //
         // If the request provides a directory, then use the worker

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -6,10 +6,16 @@
  * the stall watchdog. Extracted from index.ts for maintainability.
  */
 
-import type { MappingRequest } from './applyMappingsWorker'
+import type {
+  MappingRequest,
+  UploadError,
+  UploadResult,
+} from './applyMappingsWorker'
+import { safeSerializeError } from './applyMappingsWorker'
 import { getHttpInputHeaders, getHttpOutputHeaders } from './httpHeaders'
 import { serializeMappingOptions } from './serializeMappingOptions'
 import type {
+  TCustomUploader,
   TFileInfo,
   TFileInfoIndex,
   THashMethod,
@@ -70,6 +76,12 @@ let aborted = false
 // responses when workers query for previousMappedFileInfo.
 let currentFileInfoIndex: TFileInfoIndex | undefined
 
+// User-supplied custom uploader, set via setCustomUploader().
+let currentUploader: TCustomUploader | undefined
+
+// AbortSignal from curateMany, forwarded to currentUploader.upload() calls.
+let currentSignal: AbortSignal | undefined
+
 // Shared state accessed by both scan worker (in index.ts) and dispatch (here).
 // Exported so index.ts can push items and set the scan-finished flag.
 export let filesToProcess: {
@@ -112,6 +124,14 @@ const LOW_WATER_MARK = 50
 
 export function setMappingWorkerOptions(opts: TMappingWorkerOptions): void {
   mappingWorkerOptions = opts
+}
+
+export function setCustomUploader(uploader: TCustomUploader | undefined): void {
+  currentUploader = uploader
+}
+
+export function setAbortSignal(signal: AbortSignal | undefined): void {
+  currentSignal = signal
 }
 
 /**
@@ -198,6 +218,7 @@ export async function initializeMappingWorkers(
   workerCurrentFile.clear()
   lastWorkerProgressTime = Date.now()
   currentFileInfoIndex = fileInfoIndex
+  currentUploader = undefined
   filesToProcess = []
   directoryScanFinished = false
   scanAnomalies = []
@@ -448,6 +469,46 @@ async function createMappingWorker(): Promise<Worker> {
         response: 'lookupResult',
         postMappedHash: entry?.postMappedHash,
       })
+      return
+    }
+
+    if (event.data.response === 'upload') {
+      const msg = event.data as {
+        response: 'upload'
+        key: string
+        stream: ReadableStream<Uint8Array>
+        size: number
+        contentType?: string
+        headers?: Record<string, string>
+      }
+      if (!currentUploader) {
+        mappingWorker.postMessage({
+          response: 'uploadError',
+          error: 'No custom uploader configured',
+        } satisfies UploadError)
+        return
+      }
+      currentUploader
+        .upload({
+          key: msg.key,
+          stream: msg.stream,
+          size: msg.size,
+          contentType: msg.contentType,
+          headers: msg.headers,
+          signal: currentSignal,
+        })
+        .then((result) => {
+          mappingWorker.postMessage({
+            response: 'uploadResult',
+            etag: result.etag,
+          } satisfies UploadResult)
+        })
+        .catch((e: unknown) => {
+          mappingWorker.postMessage({
+            response: 'uploadError',
+            error: safeSerializeError(e),
+          } satisfies UploadError)
+        })
       return
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,14 @@ export type OrganizeOptions = {
   // Defaults to the platform's hardware concurrency (capped at 8).
   // Reducing this limits peak memory usage at the cost of slower throughput.
   workerCount?: number
+  /**
+   * Custom uploader for resumable / chunked uploads.
+   * Mutually exclusive with outputEndpoint.
+   * The uploader runs on the main thread; when curateMany() is used, the
+   * mapped file's ReadableStream is transferred zero-copy from the worker
+   * and handed directly to the uploader.
+   */
+  outputUploader?: TCustomUploader
   // Optional AbortSignal to cancel processing. When aborted, all workers are
   // hard-terminated and curateMany rejects with a DOMException (name: 'AbortError').
   // Equivalent to reloading the page — partially written files are detected and
@@ -143,11 +151,33 @@ export type TS3BucketOptions = {
   uploadPartSize?: number
 }
 
-/** Output target for curation -- at most one of http, directory, or s3. */
+/**
+ * Interface for a user-supplied custom uploader. Receives a ReadableStream so
+ * the implementation can perform chunked / resumable uploads without the
+ * library dictating a specific server API.
+ */
+export interface TCustomUploader {
+  upload(args: {
+    /** Output path relative to the root (URL-encoded path segments). */
+    key: string
+    /** Stream of the mapped DICOM file bytes. Consume exactly once. */
+    stream: ReadableStream<Uint8Array>
+    /** Total byte length of the file. */
+    size: number
+    contentType?: string
+    /** Derived metadata headers (X-File-*, x-source-file-hash, etc.). */
+    headers?: Record<string, string>
+    signal?: AbortSignal
+  }): Promise<{ etag?: string } & Record<string, unknown>>
+}
+
+/** Output target for curation -- at most one of http, directory, s3, or custom. */
 export type TOutputTarget = {
   http?: THTTPOptions
   directory?: FileSystemDirectoryHandle | string
   s3?: TS3BucketOptions
+  /** Tells the worker to proxy uploads to the main thread, because a custom uploader was requested. */
+  custom?: boolean
 }
 
 export type TMappingOptions = {
@@ -226,7 +256,8 @@ export type TMapResults = {
     collectByValue: [...TMappingTwoPassCollect, string | number][]
   }
   mappedBlob?: Blob
-  // Optional info when the mapped output was uploaded to a remote target
+  // Optional info when the mapped output was uploaded to a remote target.
+  // For custom uploaders, `url` holds the URL-encoded output key (not a resolvable URL).
   outputUpload?: { url: string; status: number; etag?: string }
   // If true, mapping was skipped because the file appears unchanged from previous run
   // New semantics: mappingRequired indicates that mapping must be applied.


### PR DESCRIPTION
Closes #270

Allows users of dicom-curate to "bring your own uploader". The goal is to allow (for example) for upload chunking without hardcoding a specific server-side API shape into dicom-curate.

How it works:
* User implements the `TCustomUploader` interface (basically a callback) and passes the instance over to `curateMany()`.
* dicom-curate produces a `ReadableStream` instead of writing/uploading the output directly.
* This stream is passed from worker to main thread and on to the custom uploader. The uploader is free to, say, skip some of the data if it's already been written and only write some of it.

(PRs using this functionality on Telix side will follow.)