### PR TITLE
feat: support summary-table listing specs (optional mapping + output)

### DIFF
--- a/src/collectMappings.test.ts
+++ b/src/collectMappings.test.ts
@@ -199,6 +199,120 @@ describe('collectMappings postExclude', () => {
   })
 })
 
+describe('collectMappings listing', () => {
+  type ListingCollect = (parser: {
+    getDicom: (attrName: string) => any
+    getFilePathComp: (component: string | number | symbol) => string
+    getFrom: (source: string, identifier: string) => string | number
+  }) => {
+    lookups: { [lookupField: string]: string }
+    info: (
+      | [name: string, value: string]
+      | [name: string, value: string, mode: 'list']
+    )[]
+    collect: [value: string, format: RegExp | string[], lookupField: string][]
+  }
+
+  function listingSpec(collect: ListingCollect): () => TCurationSpecification {
+    return () =>
+      makeSpec({
+        additionalData: {
+          type: 'listing',
+          collect,
+        } as TCurationSpecification['additionalData'],
+      })()
+  }
+
+  it('emits the full lookups map on the listing', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: listingSpec(() => ({
+        lookups: { PerSeries: 'series-1', PerStudy: 'study-1' },
+        info: [['Label', 'value']],
+        collect: [],
+      })),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.listing).toBeDefined()
+    expect(mapResults.listing!.lookups).toEqual({
+      PerSeries: 'series-1',
+      PerStudy: 'study-1',
+    })
+  })
+
+  it('passes through the optional info aggregation mode marker', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: listingSpec(() => ({
+        lookups: { PerSeries: 'series-1' },
+        info: [
+          ['StudyInstanceUID', 'study-1'],
+          ['SOPInstanceUIDs', 'sop-1', 'list'],
+        ],
+        collect: [],
+      })),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.listing!.info).toEqual([
+      ['StudyInstanceUID', 'study-1'],
+      ['SOPInstanceUIDs', 'sop-1', 'list'],
+    ])
+  })
+
+  it('preserves the mode marker while flattening single-element PN values', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: listingSpec(() => ({
+        lookups: { PerSeries: 'series-1' },
+        info: [
+          // dcmjs single-element PN array of digits -> flattened to Alphabetic,
+          // while the 'list' marker is retained.
+          ['PatientID', [{ Alphabetic: '12345' }] as unknown as string, 'list'],
+        ],
+        collect: [],
+      })),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.listing!.info).toEqual([['PatientID', '12345', 'list']])
+  })
+
+  it('still resolves collectByValue lookup values', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: listingSpec(() => ({
+        lookups: { PerSeries: 'series-1' },
+        info: [],
+        collect: [['Comment', /.*/, 'PerSeries']],
+      })),
+    }
+
+    const [, mapResults] = collectMappings(
+      'study/subject/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    // collectByValue appends lookups[lookupField] as the final tuple element.
+    expect(mapResults.listing!.collectByValue).toEqual([
+      ['Comment', /.*/, 'PerSeries', 'series-1'],
+    ])
+  })
+})
+
 describe('collectMappings filter error handling', () => {
   it('treats file as included and records error when preExclude throws', () => {
     const mappingOptions: TMappingOptions = {

--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -80,7 +80,8 @@ export default function collectMappings(
       return [...item, lookupValue] as [...typeof item, typeof lookupValue]
     })
 
-    // FIXME: Bug in dcmjs
+    // FIXME: Bug in dcmjs. Flatten single-element PN arrays, preserving any
+    // optional aggregation mode marker (3rd tuple element) untouched.
     const cleanedInfo = info.map((item) => {
       if (
         Array.isArray(item[1]) &&
@@ -89,13 +90,17 @@ export default function collectMappings(
         'Alphabetic' in item[1][0] &&
         /^\d+$/.test(item[1][0].Alphabetic)
       ) {
-        return [item[0], item[1][0].Alphabetic] as typeof item
+        return (
+          item.length > 2
+            ? [item[0], item[1][0].Alphabetic, item[2]]
+            : [item[0], item[1][0].Alphabetic]
+        ) as typeof item
       } else {
         return item
       }
     })
 
-    mapResults.listing = { info: cleanedInfo, collectByValue }
+    mapResults.listing = { info: cleanedInfo, collectByValue, lookups }
   }
 
   if (!mappingOptions.skipModifications) {

--- a/src/config/sampleSummaryCurationSpecification.test.ts
+++ b/src/config/sampleSummaryCurationSpecification.test.ts
@@ -1,0 +1,83 @@
+import { sample } from '../../testdata/sample'
+import collectMappings from '../collectMappings'
+import { composeSpecs } from '../composeSpecs'
+import type { TMappingOptions } from '../types'
+import { sampleSummaryCurationSpecification } from './sampleSummaryCurationSpecification'
+
+describe('sampleSummaryCurationSpecification', () => {
+  it('declares listing output and omits mapping (summary-table shape)', () => {
+    const spec = composeSpecs(sampleSummaryCurationSpecification())
+
+    expect(spec.additionalData?.type).toBe('listing')
+    // No CSV mapping -> consumers run single-pass summary mode.
+    expect(spec.additionalData?.mapping).toBeUndefined()
+
+    const additionalData = spec.additionalData as {
+      type: 'listing'
+      output?: { path: string; rowKey: string }
+    }
+    expect(additionalData.output).toEqual({
+      path: 'reports/series_summary.csv',
+      rowKey: 'PerSeries',
+    })
+  })
+
+  it('output.rowKey is a key of the lookups returned by collect()', () => {
+    const spec = composeSpecs(sampleSummaryCurationSpecification())
+    const additionalData = spec.additionalData as {
+      type: 'listing'
+      output: { rowKey: string }
+      collect: (parser: {
+        getDicom: (n: string) => any
+        getFilePathComp: (c: string | number | symbol) => string
+        getFrom: (s: string, i: string) => string | number
+      }) => { lookups: Record<string, string> }
+    }
+
+    const dummyParser = {
+      getDicom: () => '',
+      getFilePathComp: () => '',
+      getFrom: () => '',
+    }
+    const { lookups } = additionalData.collect(dummyParser)
+
+    expect(Object.keys(lookups)).toContain(additionalData.output.rowKey)
+  })
+
+  it('produces a listing carrying lookups and the list-mode info marker', () => {
+    const mappingOptions: TMappingOptions = {
+      curationSpec: sampleSummaryCurationSpecification,
+      skipModifications: true,
+    }
+
+    const [, mapResults] = collectMappings(
+      'FolderX/FolderY/test.dcm',
+      sample,
+      mappingOptions,
+    )
+
+    expect(mapResults.listing).toBeDefined()
+    // rowKey lookup is present on every listing row.
+    expect(mapResults.listing!.lookups).toHaveProperty('PerSeries')
+
+    const labels = mapResults.listing!.info.map((entry) => entry[0])
+    expect(labels).toEqual([
+      'StudyInstanceUID',
+      'SeriesInstanceUID',
+      'SeriesDescription',
+      'FolderX',
+      'FolderY',
+      'SOPInstanceUIDs',
+    ])
+
+    // FolderX / FolderY come from the input path components.
+    const folderX = mapResults.listing!.info.find((e) => e[0] === 'FolderX')
+    const folderY = mapResults.listing!.info.find((e) => e[0] === 'FolderY')
+    expect(folderX?.[1]).toBe('FolderX')
+    expect(folderY?.[1]).toBe('FolderY')
+
+    // SOPInstanceUIDs retains its 'list' aggregation marker downstream.
+    const sop = mapResults.listing!.info.find((e) => e[0] === 'SOPInstanceUIDs')
+    expect(sop?.[2]).toBe('list')
+  })
+})

--- a/src/config/sampleSummaryCurationSpecification.test.ts
+++ b/src/config/sampleSummaryCurationSpecification.test.ts
@@ -1,7 +1,7 @@
 import { sample } from '../../testdata/sample'
 import collectMappings from '../collectMappings'
 import { composeSpecs } from '../composeSpecs'
-import type { TMappingOptions } from '../types'
+import type { TCurationSpecification, TMappingOptions } from '../types'
 import { sampleSummaryCurationSpecification } from './sampleSummaryCurationSpecification'
 
 describe('sampleSummaryCurationSpecification', () => {
@@ -79,5 +79,52 @@ describe('sampleSummaryCurationSpecification', () => {
     // SOPInstanceUIDs retains its 'list' aggregation marker downstream.
     const sop = mapResults.listing!.info.find((e) => e[0] === 'SOPInstanceUIDs')
     expect(sop?.[2]).toBe('list')
+  })
+
+  it('forbids a listing spec with both mapping and output (type-level)', () => {
+    const base = {
+      version: '3.0',
+      hostProps: {},
+      dicomPS315EOptions: 'Off',
+      inputPathPattern: 'any',
+      modifyDicomHeader: () => ({}),
+      outputFilePathComponents: () => [],
+      errors: () => [],
+    } as const
+
+    // Valid: summary variant (output, no mapping).
+    const summary: TCurationSpecification = {
+      ...base,
+      additionalData: {
+        type: 'listing',
+        collect: () => ({ lookups: {}, info: [], collect: [] }),
+        output: { path: 'reports/summary.csv', rowKey: 'PerSeries' },
+      },
+    }
+
+    // Valid: curate variant (mapping, no output).
+    const curate: TCurationSpecification = {
+      ...base,
+      additionalData: {
+        type: 'listing',
+        collect: () => ({ lookups: {}, info: [], collect: [] }),
+        mapping: {},
+      },
+    }
+
+    const illegal: TCurationSpecification = {
+      ...base,
+      additionalData: {
+        type: 'listing',
+        collect: () => ({ lookups: {}, info: [], collect: [] }),
+        mapping: {},
+        // @ts-expect-error mapping and output are mutually exclusive
+        output: { path: 'reports/summary.csv', rowKey: 'PerSeries' },
+      },
+    }
+
+    expect(summary.additionalData?.type).toBe('listing')
+    expect(curate.additionalData?.type).toBe('listing')
+    expect(illegal.additionalData?.type).toBe('listing')
   })
 })

--- a/src/config/sampleSummaryCurationSpecification.ts
+++ b/src/config/sampleSummaryCurationSpecification.ts
@@ -1,0 +1,60 @@
+import type { TCurationSpecification } from '../types'
+
+/*
+ * Sample of a summary-table curation specification.
+ *
+ * This is a single-pass, read-only spec: it declares `additionalData.output`
+ * and omits `additionalData.mapping`. Consumers (e.g. MedEx) detect this shape
+ * and, instead of writing curated DICOMs, aggregate the per-file `listing`
+ * data into a CSV summary table written to `output.path`.
+ *
+ * One CSV row is emitted per unique value of `lookups[output.rowKey]`
+ * (here, per unique SeriesInstanceUID). The CSV columns are the `info`
+ * entries, in declaration order:
+ *   StudyInstanceUID, SeriesInstanceUID, SeriesDescription,
+ *   FolderX, FolderY, SOPInstanceUIDs
+ *
+ * `info` entries default to first-wins within a row group. The optional third
+ * tuple element 'list' aggregates distinct values across the group, joined
+ * with ';' (used here for SOPInstanceUIDs so every instance is captured).
+ */
+export function sampleSummaryCurationSpecification(): TCurationSpecification {
+  const hostProps = { protocolNumber: 'Demo' }
+
+  return {
+    inputPathPattern: 'any',
+
+    additionalData: {
+      type: 'listing',
+      collect: (parser) => ({
+        lookups: {
+          PerSeries: parser.getDicom('SeriesInstanceUID'),
+        },
+        info: [
+          ['StudyInstanceUID', parser.getDicom('StudyInstanceUID')],
+          ['SeriesInstanceUID', parser.getDicom('SeriesInstanceUID')],
+          ['SeriesDescription', parser.getDicom('SeriesDescription')],
+          ['FolderX', parser.getFilePathComp(0)],
+          ['FolderY', parser.getFilePathComp(1)],
+          ['SOPInstanceUIDs', parser.getDicom('SOPInstanceUID'), 'list'],
+        ],
+        collect: [],
+      }),
+      output: {
+        path: 'reports/series_summary.csv',
+        rowKey: 'PerSeries',
+      },
+      // No `mapping` => single pass, write CSV summary instead of DICOMs.
+    },
+
+    version: '3.0',
+    hostProps,
+
+    // No de-identification or header modification in summary mode.
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    // Unused when consumers run with skipModifications.
+    outputFilePathComponents: () => [],
+    errors: () => [],
+  }
+}

--- a/src/curateMany.test.ts
+++ b/src/curateMany.test.ts
@@ -139,6 +139,63 @@ describe('curateMany', () => {
     expect(mappingWorkerPool.dispatchMappingJobs).not.toHaveBeenCalled()
   })
 
+  it('rejects when a summary spec (additionalData.output) runs without skipWrite', async () => {
+    ;(
+      composeSpecsModule.composeSpecs as MockedFunction<
+        typeof composeSpecsModule.composeSpecs
+      >
+    ).mockReturnValueOnce({
+      dicomPS315EOptions: 'Off',
+      additionalData: {
+        type: 'listing',
+        collect: () => ({ lookups: {}, info: [], collect: [] }),
+        output: { path: 'reports/summary.csv', rowKey: 'PerSeries' },
+      },
+    } as any)
+
+    await expect(
+      curateMany({
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: () => ({}),
+        // skipWrite omitted -> defaults to false -> must reject
+      } as any),
+    ).rejects.toThrow(
+      'additionalData.output (summary-table mode) requires skipWrite: true',
+    )
+
+    expect(mappingWorkerPool.setMappingWorkerOptions).not.toHaveBeenCalled()
+    expect(mappingWorkerPool.dispatchMappingJobs).not.toHaveBeenCalled()
+  })
+
+  it('accepts a summary spec (additionalData.output) when skipWrite is true', async () => {
+    ;(
+      composeSpecsModule.composeSpecs as MockedFunction<
+        typeof composeSpecsModule.composeSpecs
+      >
+    ).mockReturnValue({
+      dicomPS315EOptions: 'Off',
+      additionalData: {
+        type: 'listing',
+        collect: () => ({ lookups: {}, info: [], collect: [] }),
+        output: { path: 'reports/summary.csv', rowKey: 'PerSeries' },
+      },
+    } as any)
+
+    const promise = curateMany({
+      inputType: 'http',
+      inputUrls: ['https://example.com/file.dcm'],
+      curationSpec: () => ({}),
+      skipWrite: true,
+    } as any)
+
+    await flushAsyncSetup()
+    emitDone()
+    await expect(promise).resolves.toBeDefined()
+
+    expect(mappingWorkerPool.setMappingWorkerOptions).toHaveBeenCalled()
+  })
+
   it('rejects with AbortError if aborted while async setup is still in progress', async () => {
     let resolveInit!: () => void
     ;(

--- a/src/getParser.ts
+++ b/src/getParser.ts
@@ -76,16 +76,18 @@ export default function getParser(
   }
 
   const getMapping =
-    !additionalData || !columnMappings
+    !additionalData || !additionalData.mapping || !columnMappings
       ? undefined
       : // key: one of the keys defined in the `mapping` object
-        function getMapping(key: string) {
-          const { mapping } = additionalData
-          const { value: valueFn } = mapping[key]
-          const value = valueFn({ getDicom, getFilePathComp, getFrom })
+        (() => {
+          const mapping = additionalData.mapping
+          return function getMapping(key: string) {
+            const { value: valueFn } = mapping[key]
+            const value = valueFn({ getDicom, getFilePathComp, getFrom })
 
-          return getCsvMapping(columnMappings, mapping, key, value)
-        }
+            return getCsvMapping(columnMappings, mapping, key, value)
+          }
+        })()
 
   function missingDicom(attrName: string) {
     const value = getDicom(attrName)

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,20 @@ async function collectMappingOptions(
   const hashMethod = organizeOptions.hashMethod
   const hashPartSize = organizeOptions.hashPartSize
 
+  // Summary-table mode (additionalData.output set) produces a CSV summary and
+  // no curated DICOMs, so it must run read-only. skipWrite is the option that
+  // actually prevents any file from being written/transferred (skipModifications
+  // only governs whether content is changed). Fail fast on misuse.
+  if (
+    additionalData?.type === 'listing' &&
+    additionalData.output &&
+    !skipWrite
+  ) {
+    throw new Error(
+      'additionalData.output (summary-table mode) requires skipWrite: true — summary specs produce a CSV summary and no curated output.',
+    )
+  }
+
   const dateOffset = organizeOptions.dateOffset
 
   if (requiresDateOffset(deIdOpts) && !dateOffset?.match(iso8601)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ async function collectMappingOptions(
   // The need for mapping can come from additionalData or from the
   // retainLongitudinalTemporalInformationOptions option
   let columnMappings: TColumnMappings | undefined
-  if (organizeOptions.table && additionalData) {
+  if (organizeOptions.table && additionalData?.mapping) {
     columnMappings = extractColumnMappings(
       organizeOptions.table,
       additionalData.mapping,

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,8 @@ type TMappingInputDirect = {
   // load: csv file
   type: 'load'
   collect: Record<string, RegExp | string[]>
+  // Direct (CSV-load) mapping. Required for this flow.
+  mapping: TMappedValues
 }
 
 // Optional aggregation marker on an info entry. When omitted, the value is
@@ -334,6 +336,17 @@ type TMappingTwoPassCollect = [
   lookupField: string,
 ]
 
+// Summary-table output. When set (curate variant omitted), consumers run a
+// single read-only pass and emit a CSV summary table instead of curated
+// DICOMs. One CSV row per unique value of lookups[rowKey].
+type TSummaryOutput = {
+  // CSV path relative to the curation output root, e.g.
+  // 'reports/series_summary.csv'.
+  path: string
+  // A key of the `lookups` map returned by collect(). Defines the row group.
+  rowKey: string
+}
+
 type TMappingInputTwoPass = {
   // two-pass: extract from listing.
   type: 'listing'
@@ -344,17 +357,19 @@ type TMappingInputTwoPass = {
     info: TMappingTwoPassInfo[]
     collect: TMappingTwoPassCollect[]
   }
-  // Optional summary output. When present (and `additionalData.mapping` is
-  // absent), consumers run a single pass and emit a CSV summary table instead
-  // of curated DICOMs. One CSV row per unique value of lookups[rowKey].
-  output?: {
-    // CSV path relative to the curation output root, e.g.
-    // 'reports/series_summary.csv'.
-    path: string
-    // A key of the `lookups` map returned by collect(). Defines the row group.
-    rowKey: string
-  }
-}
+} & (
+  | {
+      // Curate variant: two-pass form / mapping, writes curated DICOMs.
+      mapping: TMappedValues
+      output?: never
+    }
+  | {
+      // Summary variant: read-only pass, writes a CSV summary table.
+      // `mapping` is mutually exclusive with `output` (enforced by the type).
+      output: TSummaryOutput
+      mapping?: never
+    }
+)
 
 type HPPrimitive =
   | string
@@ -377,12 +392,11 @@ export type TCurationSpecification<THost extends HostProps = HostProps> = {
   dicomPS315EOptions: TPs315Options | 'Off'
   inputPathPattern: string
   hostProps: THost
-  // `mapping` is optional: it is required for the two-pass form / CSV-load
-  // flows, but omitted in summary-table mode (TMappingInputTwoPass.output set).
-  additionalData?: { mapping?: TMappedValues } & (
-    | TMappingInputDirect
-    | TMappingInputTwoPass
-  )
+  // Curation mapping input. `mapping` and the summary `output` are mutually
+  // exclusive: a 'load' or two-pass 'listing' spec carries `mapping` and
+  // writes curated DICOMs, while a summary 'listing' spec carries `output`
+  // and is read-only. Enforced at the type level by the member unions.
+  additionalData?: TMappingInputDirect | TMappingInputTwoPass
   excludedFiletypes?: string[]
   // Called with original (pre-mapping) DICOM tags. Return true to exclude (skip) the file.
   //

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,10 @@ export type TMapResults = {
   listing?: {
     info: TMappingTwoPassInfo[]
     collectByValue: [...TMappingTwoPassCollect, string | number][]
+    // Full lookups map for this file, so consumers can group rows by an
+    // arbitrary lookup key (including ones not referenced by any collect[]
+    // entry). Required for summary-table mode where collect may be empty.
+    lookups: { [lookupField: string]: string }
   }
   mappedBlob?: Blob
   // Optional info when the mapped output was uploaded to a remote target.
@@ -316,7 +320,14 @@ type TMappingInputDirect = {
   collect: Record<string, RegExp | string[]>
 }
 
-type TMappingTwoPassInfo = [name: string, value: string]
+// Optional aggregation marker on an info entry. When omitted, the value is
+// treated as first-wins within a summary row group. 'list' collects distinct
+// values across the group. The union is open for forward-compatible modes
+// (e.g. 'count', 'set', 'min', 'max') added later without breaking specs.
+type TMappingTwoPassInfoMode = 'list'
+type TMappingTwoPassInfo =
+  | [name: string, value: string]
+  | [name: string, value: string, mode: TMappingTwoPassInfoMode]
 type TMappingTwoPassCollect = [
   value: string,
   format: RegExp | string[],
@@ -332,6 +343,16 @@ type TMappingInputTwoPass = {
     lookups: { [lookupField: string]: string }
     info: TMappingTwoPassInfo[]
     collect: TMappingTwoPassCollect[]
+  }
+  // Optional summary output. When present (and `additionalData.mapping` is
+  // absent), consumers run a single pass and emit a CSV summary table instead
+  // of curated DICOMs. One CSV row per unique value of lookups[rowKey].
+  output?: {
+    // CSV path relative to the curation output root, e.g.
+    // 'reports/series_summary.csv'.
+    path: string
+    // A key of the `lookups` map returned by collect(). Defines the row group.
+    rowKey: string
   }
 }
 
@@ -356,7 +377,9 @@ export type TCurationSpecification<THost extends HostProps = HostProps> = {
   dicomPS315EOptions: TPs315Options | 'Off'
   inputPathPattern: string
   hostProps: THost
-  additionalData?: { mapping: TMappedValues } & (
+  // `mapping` is optional: it is required for the two-pass form / CSV-load
+  // flows, but omitted in summary-table mode (TMappingInputTwoPass.output set).
+  additionalData?: { mapping?: TMappedValues } & (
     | TMappingInputDirect
     | TMappingInputTwoPass
   )


### PR DESCRIPTION
Closes #276

## Summary

Allow a two-pass `listing` curation spec to describe a **read-only aggregation pass** that produces a summary table, instead of a curation pass that writes DICOMs. The behaviour is selected purely by the **shape of the spec** — a spec opts in by declaring `additionalData.output` and omitting `additionalData.mapping`. Consumers that detect this shape run a single pass and aggregate the per-file `listing` records (one row per unique `lookups[rowKey]`) instead of curating.

## Changes (additive, backward-compatible)

- **`src/types.ts`**
  - `additionalData.mapping` is now **optional** (required only for the form/CSV-load flows; absent in summary mode).
  - `TMappingInputTwoPass` gains optional `output?: { path: string; rowKey: string }`.
  - `TMappingTwoPassInfo` allows an optional third tuple element — an aggregation-mode marker, initially `'list'` (collect distinct values per row group); union left open for future modes.
  - `TMapResults.listing` gains `lookups: { [field: string]: string }` so consumers can group by an arbitrary `rowKey`, including keys not referenced by any `collect[]` entry (needed for `collect: []`).
- **`src/collectMappings.ts`** — emit the full `lookups` map on the listing; preserve any `info` mode marker through PN-value cleaning.
- **`src/getParser.ts` / `src/index.ts`** — tolerate a missing `mapping` (skip `getMapping` / column-mapping extraction) so summary specs with `collect: []` compose and run.
- **`src/config/sampleSummaryCurationSpecification.ts`** — sample summary spec (one row per `SeriesInstanceUID`; `SOPInstanceUID` aggregated via `'list'`).

## Spec-shape matrix

| `type` | `mapping` | `output` | Flow |
|---|---|---|---|
| absent / other | n/a | n/a | 1-pass, write DICOMs |
| `'listing'` | present | absent | 2-pass mapping, write DICOMs (today) |
| `'listing'` | absent | present | **NEW**: read-only summary table |
| `'listing'` | present | present | out of scope (future) |

## Scope

Library primitives only. CSV serialization/writing live in the consumer, which detects the summary shape and aggregates `listing` records. No CSV writer is added here (no `rows → text` helper exists today and one isn't needed for this change).

## Backward compatibility

Fully additive. Existing specs (no `output`, `mapping` present) are unaffected — `mapping` becoming optional only relaxes a constraint; the listing now additionally carries `lookups`.

## Tests

- `collectMappings.test.ts`: listing carries `lookups`; `info` mode marker passes through (incl. PN-flatten case); `collectByValue` still resolves.
- `sampleSummaryCurationSpecification.test.ts`: spec composes, `rowKey ∈ lookups`, end-to-end through `collectMappings`.