### PR TITLE
Gracefully handle getFile() errors instead of killing the process (#283)

### DIFF
--- a/src/curateOne.ts
+++ b/src/curateOne.ts
@@ -321,10 +321,12 @@ export async function curateOne({
         error,
       )
       const mapResults = {
-        anomalies: [`Could not parse ${fileInfo.name} as DICOM data`],
-        errors: [
-          `File ${fileInfo.name} is not a valid DICOM file or is corrupted`,
-        ],
+        // PHI-safe strings: the raw filename is intentionally omitted because
+        // anomalies/errors are shared between the private (input) log and the
+        // server-bound (output) log. The raw name/path is carried only in
+        // fileInfo, keeping it in the private log. See #283.
+        anomalies: [`Could not parse file as DICOM data`],
+        errors: [`File is not a valid DICOM file or is corrupted`],
         sourceInstanceUID: `invalid_${fileInfo.name.replace(/[^a-zA-Z0-9]/g, '_')}`,
         fileInfo: {
           name: fileInfo.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,8 +119,8 @@ async function initializeFileListWorker(
         }
         case 'scanAnomalies': {
           // Handle scan anomalies separately - they don't go to processing
-          const { fileInfo: anomalyFileInfo, anomalies } = event.data
-          scanAnomalies.push({ fileInfo: anomalyFileInfo, anomalies })
+          const { fileInfo: anomalyFileInfo, anomalies, errors } = event.data
+          scanAnomalies.push({ fileInfo: anomalyFileInfo, anomalies, errors })
           break
         }
         case 'count': {

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -97,7 +97,11 @@ export function setDirectoryScanFinished(value: boolean): void {
 }
 
 // Track scan anomalies separately since they don't go through the processing pipeline
-export let scanAnomalies: { fileInfo: TFileInfo; anomalies: string[] }[] = []
+export let scanAnomalies: {
+  fileInfo: TFileInfo
+  anomalies: string[]
+  errors?: string[]
+}[] = []
 
 // Callbacks set by curateMany, stored here for use by the dispatch loop.
 let progressCallback: ProgressCallback = () => {}
@@ -297,10 +301,41 @@ export async function dispatchMappingJobs(): Promise<void> {
 
     if (!mapResultsList) mapResultsList = []
 
-    // Create individual mapResults entries for each scan anomaly
-    // Only do this during actual processing (not first pass)
-    if (!mappingWorkerOptions.skipWrite) {
-      scanAnomalies.forEach(({ fileInfo, anomalies }) => {
+    // Create individual mapResults entries for each scan finding.
+    //
+    // Two kinds of scan findings are surfaced differently:
+    //
+    //  - Benign anomalies (non-DICOM, too-small, excluded filetypes): noise
+    //    during the first pass (form generation), so only emitted on the
+    //    write pass (!skipWrite), and they carry the input path in
+    //    `outputFilePath` as before.
+    //
+    //  - Hard read errors (file could not be read at all): always surfaced,
+    //    in both passes, via `errors`. We deliberately OMIT `outputFilePath`
+    //    so the raw input path is not leaked into the server-bound log; the
+    //    raw path is retained in `fileInfo` for the private (input) log, and a
+    //    path-less trace is rendered in the server-bound log by the consumer.
+    scanAnomalies.forEach(({ fileInfo, anomalies, errors }) => {
+      const hasReadErrors = !!errors && errors.length > 0
+
+      if (hasReadErrors) {
+        const scanErrorResult: TMapResults = {
+          sourceInstanceUID: `scan_${fileInfo.name.replace(/[^a-zA-Z0-9]/g, '_')}`,
+          // Intentionally no outputFilePath: an unread file has no
+          // de-identified output path, and we must not place the raw input
+          // path in the server-bound channel.
+          mappings: {},
+          anomalies: anomalies ?? [],
+          errors,
+          quarantine: {},
+          fileInfo,
+        }
+        mapResultsList!.push(scanErrorResult)
+        return
+      }
+
+      // Benign anomalies: only on the write pass.
+      if (!mappingWorkerOptions.skipWrite && anomalies.length > 0) {
         const scanAnomalyResult: TMapResults = {
           sourceInstanceUID: `scan_${fileInfo.name.replace(/[^a-zA-Z0-9]/g, '_')}`,
           outputFilePath: `${fileInfo.path}/${fileInfo.name}`, // Use the actual file path
@@ -309,11 +344,9 @@ export async function dispatchMappingJobs(): Promise<void> {
           errors: [],
           quarantine: {},
         }
-
-        // Add each scan anomaly result to the final results
         mapResultsList!.push(scanAnomalyResult)
-      })
-    }
+      }
+    })
 
     progressCallback({
       response: 'done',

--- a/src/scanDirectoryWorker.ts
+++ b/src/scanDirectoryWorker.ts
@@ -12,6 +12,19 @@ const DEFAULT_EXCLUDED_FILETYPES = [
   '.ds_store',
 ]
 
+/**
+ * Build a PHI-safe error message for a file that could not be read during
+ * scanning. Intentionally omits the filename/path so the string is safe to
+ * place in `errors` (which is shared between the private and server-bound
+ * logs). The raw path/name is carried separately in `fileInfo` so it appears
+ * only in the private (input) log.
+ */
+function safeReadErrorMessage(error: unknown): string {
+  const detail =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+  return `Unable to read file (filesystem error): ${detail}`
+}
+
 export type FileScanMsg =
   | {
       response: 'file'
@@ -26,6 +39,15 @@ export type FileScanMsg =
       response: 'scanAnomalies'
       fileInfo: TFileInfo
       anomalies: string[]
+      /**
+       * Hard errors discovered during scanning (e.g. a file that cannot be
+       * read at all via the FileSystem API / fs.stat). Unlike `anomalies`
+       * (benign findings such as non-DICOM or too-small files), these are
+       * surfaced as errors so they are visible regardless of pass. The string
+       * MUST NOT contain the raw filename/path — that is carried only in
+       * `fileInfo` so it stays in the private (input) log.
+       */
+      errors?: string[]
       previousFileInfo?: {
         size?: number
         mtime?: string
@@ -554,9 +576,41 @@ async function scanDirectory(dir: FileSystemDirectoryHandle) {
       if (!keepScanning) return
 
       if (entry.kind === 'file') {
-        const file = await (entry as FileSystemFileHandle).getFile()
         const key = `${prefix}/${entry.name}`
         const prev = previousIndex ? previousIndex[key] : undefined
+
+        let file: File
+        try {
+          file = await (entry as FileSystemFileHandle).getFile()
+        } catch (readError) {
+          // A single file we cannot read (corrupted, locked, permission
+          // revoked via the Chromium FileSystem API) must NOT abort the whole
+          // scan. Report it as a hard error and continue. The error string is
+          // PHI-safe (no filename); the raw path/name lives only in fileInfo,
+          // which keeps it in the private (input) log.
+          if (cheapFilterNameOnly(entry.name, key)) {
+            totalDiscovered--
+            globalThis.postMessage({
+              response: 'count',
+              totalDiscovered,
+            } satisfies FileScanMsg)
+          }
+          globalThis.postMessage({
+            response: 'scanAnomalies',
+            fileInfo: {
+              path: prefix,
+              name: entry.name,
+              size: 0,
+              kind: 'handle',
+              fileHandle: entry as FileSystemFileHandle,
+            },
+            anomalies: [],
+            errors: [safeReadErrorMessage(readError)],
+            previousFileInfo: prev,
+          } satisfies FileScanMsg)
+          if (!(await waitIfPaused())) return
+          continue
+        }
 
         const fileAnomalies: string[] = []
         if (await shouldProcessFile(file, fileAnomalies, key)) {
@@ -685,9 +739,40 @@ async function scanDirectoryNode(dirPath: string) {
 
         if (entry.isFile()) {
           const filePath = path.join(currentPath, entry.name)
-          const stats = await fs.stat(filePath)
           const key = `${prefix}/${entry.name}`
           const prev = previousIndex ? previousIndex[key] : undefined
+
+          let stats: Awaited<ReturnType<typeof fs.stat>>
+          try {
+            stats = await fs.stat(filePath)
+          } catch (readError) {
+            // A single file we cannot stat (vanished, permission denied) must
+            // NOT abort the whole scan. Report it as a hard error and continue.
+            // The error string is PHI-safe (no path); the raw path lives only
+            // in fileInfo, keeping it in the private (input) log.
+            if (cheapFilterNameOnly(entry.name, key)) {
+              totalDiscovered--
+              globalThis.postMessage({
+                response: 'count',
+                totalDiscovered,
+              } satisfies FileScanMsg)
+            }
+            globalThis.postMessage({
+              response: 'scanAnomalies',
+              fileInfo: {
+                path: prefix,
+                name: entry.name,
+                size: 0,
+                kind: 'path',
+                fullPath: filePath,
+              },
+              anomalies: [],
+              errors: [safeReadErrorMessage(readError)],
+              previousFileInfo: prev,
+            } satisfies FileScanMsg)
+            if (!(await waitIfPaused())) return
+            continue
+          }
 
           const fileAnomalies: string[] = []
           if (

--- a/src/scannerCounting.test.ts
+++ b/src/scannerCounting.test.ts
@@ -276,3 +276,113 @@ describe('parallel counter + feeder', () => {
     expect(scanWorkerInstance?.terminated).toBe(true)
   })
 })
+
+describe('scan read-failures (getFile/stat) are non-fatal', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = createTestDicomDir(20, {
+      studyDescription: 'Read Failure Test',
+      subdirName: 'RF-001',
+    })
+  })
+
+  afterAll(() => {
+    cleanupTestDicomDir(dir)
+  })
+
+  afterEach(() => {
+    scanWorkerInstance?.terminate()
+    resetMockWorkers()
+    resetParallelScanWorker()
+    scanWorkerInstance = undefined
+  })
+
+  it('does not abort the run; surfaces unreadable files as errors with no output path', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+    configureParallelScanWorker({ readErrorCount: 3 })
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: dir,
+        curationSpec: minimalSpec,
+        skipWrite: false,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    // The run completes (not rejected) despite 3 unreadable files.
+    expect(result.response).toBe('done')
+
+    const readErrorResults = result.mapResultsList!.filter(
+      (r) =>
+        r.sourceInstanceUID?.startsWith('scan_') &&
+        r.errors &&
+        r.errors.length > 0,
+    )
+    expect(readErrorResults).toHaveLength(3)
+
+    for (const r of readErrorResults) {
+      // PHI-safe error string, no filename.
+      expect(r.errors[0]).toContain('Unable to read file (filesystem error)')
+      // No output path: must not leak the raw input path to the server log.
+      expect(r.outputFilePath).toBeUndefined()
+      // fileInfo retained so the private (input) log can reference the path.
+      expect(r.fileInfo).toBeDefined()
+      expect(r.fileInfo?.name).toBeTruthy()
+    }
+  })
+
+  it('surfaces read-failures even during the first pass (skipWrite)', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+    configureParallelScanWorker({ readErrorCount: 2 })
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: dir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+
+    const readErrorResults = result.mapResultsList!.filter(
+      (r) =>
+        r.sourceInstanceUID?.startsWith('scan_') &&
+        r.errors &&
+        r.errors.length > 0,
+    )
+    // Read-failures bypass the first-pass suppression that benign anomalies obey.
+    expect(readErrorResults).toHaveLength(2)
+  })
+
+  it('benign scan anomalies remain suppressed during the first pass', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+    configureParallelScanWorker({ rejectCount: 3 })
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: dir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+
+    const anomalyResults = result.mapResultsList!.filter((r) =>
+      r.sourceInstanceUID?.startsWith('scan_'),
+    )
+    // Benign anomalies are not emitted on the first pass.
+    expect(anomalyResults).toHaveLength(0)
+  })
+})

--- a/testutils/mockParallelScanWorker.ts
+++ b/testutils/mockParallelScanWorker.ts
@@ -22,16 +22,22 @@ import { join } from 'path'
 // Module-level configuration
 // ---------------------------------------------------------------------------
 
-let nextOptions: { rejectCount?: number; emissionDelay?: number } = {}
+let nextOptions: {
+  rejectCount?: number
+  emissionDelay?: number
+  readErrorCount?: number
+} = {}
 
 /**
  * Configure options for the next ParallelScanWorker instance.
  * @param options.rejectCount Number of files the feeder will reject (correcting the count).
  * @param options.emissionDelay Delay in ms between feeder file emissions (default 0).
+ * @param options.readErrorCount Number of files that fail to read (emit scanAnomalies with `errors`).
  */
 export function configureParallelScanWorker(options: {
   rejectCount?: number
   emissionDelay?: number
+  readErrorCount?: number
 }): void {
   nextOptions = { ...options }
 }
@@ -60,6 +66,9 @@ export class ParallelScanWorker {
   /** Number of files the feeder will reject (simulating full-filter failures). */
   public rejectCount: number
 
+  /** Number of files the feeder will fail to read (read-error scanAnomalies). */
+  public readErrorCount: number
+
   /** Delay between feeder emissions (ms). */
   public emissionDelay: number
 
@@ -69,11 +78,13 @@ export class ParallelScanWorker {
   private totalDiscovered = 0
   private feederIndex = 0
   private rejectedSoFar = 0
+  private readErrorsSoFar = 0
   private paused = false
   private pendingTimeout: ReturnType<typeof setTimeout> | null = null
 
   constructor() {
     this.rejectCount = nextOptions.rejectCount ?? 0
+    this.readErrorCount = nextOptions.readErrorCount ?? 0
     this.emissionDelay = nextOptions.emissionDelay ?? 0
   }
 
@@ -108,6 +119,7 @@ export class ParallelScanWorker {
         this.totalDiscovered = 0
         this.feederIndex = 0
         this.rejectedSoFar = 0
+        this.readErrorsSoFar = 0
         this.paused = false
 
         // Counter: emit all 'count' messages immediately (synchronous).
@@ -174,9 +186,20 @@ export class ParallelScanWorker {
     const fileIndex = this.feederIndex
     this.feederIndex++
 
+    // Should this file fail to read entirely (read-error)?
+    const shouldReadError = this.readErrorsSoFar < this.readErrorCount
     // Should this file be rejected by the full filter?
-    const shouldReject = this.rejectedSoFar < this.rejectCount
-    if (shouldReject) {
+    const shouldReject =
+      !shouldReadError && this.rejectedSoFar < this.rejectCount
+    if (shouldReadError) {
+      this.readErrorsSoFar++
+      this.totalDiscovered--
+      this.emit({
+        response: 'count',
+        totalDiscovered: this.totalDiscovered,
+      })
+      this.emitReadErrorAtIndex(fileIndex)
+    } else if (shouldReject) {
       this.rejectedSoFar++
       this.totalDiscovered--
       this.emit({
@@ -232,6 +255,30 @@ export class ParallelScanWorker {
         size: stat.size,
       },
       anomalies: ['Skipped file without DICOM signature: ' + name],
+    })
+  }
+
+  private emitReadErrorAtIndex(fileIndex: number): void {
+    if (this.terminated) return
+
+    const relPath = this.files[fileIndex]
+    const parts = relPath.split('/')
+    const name = parts.pop()!
+    const path = parts.join('/')
+
+    // Read-error: the file could not be read at all, so size is unknown (0)
+    // and we surface a PHI-safe error string (no filename). The real worker
+    // does the same.
+    this.emit({
+      response: 'scanAnomalies',
+      fileInfo: {
+        kind: 'path',
+        path: join(this.scanDir, path),
+        name,
+        size: 0,
+      },
+      anomalies: [],
+      errors: ['Unable to read file (filesystem error): Error: EACCES'],
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes #283. A single unreadable file during directory scanning previously aborted the **entire** `curateMany` run. The unguarded `getFile()` (browser) / `fs.stat()` (node) call in the scan feeders bubbled to the function-level `catch`, which posted `response: 'error'` and terminated all workers — so one corrupted/locked/permission-denied file killed the whole batch.

## Changes

**1. Scan read-failure resilience (`scanDirectoryWorker.ts`, `mappingWorkerPool.ts`, `index.ts`)**
- Wrap the per-file read in both scan feeders (browser `getFile`, node `fs.stat`) in `try/catch`. On failure, emit the file through the existing `scanAnomalies` message carrying a new optional `errors[]` payload, then `continue`.
- The error string is **PHI-safe** (no filename); the raw path/name is retained only in `fileInfo`, so it stays in the private (input) log.
- `mappingWorkerPool` turns read-failure findings into `scan_*` mapResults with `errors` populated and **no `outputFilePath`** (so the raw input path is never leaked to the server-bound log), and surfaces them in **both passes**. Benign anomalies keep their existing first-pass suppression and input-path behavior.

**2. Converge `curateOne` parse-failure to the same PHI-safe pattern (`curateOne.ts`)**
- Drop the raw filename from the parse-failure `anomalies[]` / `errors[]` strings (those arrays are shared verbatim between the private and server-bound logs). The name/path is retained in `fileInfo` only. The dev-only `console.warn` keeps the name for local debugging.

## Behavior

- A file that cannot be read is now reported as an **error** (red diagnostic in the consuming UI) and the run **continues**, instead of aborting.
- Errors and anomalies no longer embed raw filenames, so they are safe to place in the shareable (server-bound) log.

## Tests

- New mock + pool tests asserting: the run is not aborted; unreadable files surface as `scan_*` results with `errors` populated, no `outputFilePath`, and `fileInfo` retained; read-failures surface in **both** passes while benign anomalies stay suppressed on the first pass.
- Full unit suite green (237 tests).

## Consumer note

The companion consumer-side change (path-less server-log trace) lives in the ims-platform `dicom-curate-utils` library. ims-platform must bump its `dicom-curate` dependency to the published version that includes this PR before the end-to-end fix takes effect.