### PR TITLE
Feat/expose meta to preexclude

### DIFF
--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -34,6 +34,12 @@ export default function collectMappings(
   const naturalData = dcmjs.data.DicomMetaDictionary.naturalizeDataset(
     dicomData.dict,
   )
+  // File meta group (0002), kept separate from the dataset so preExclude can
+  // reach MediaStorageSOPClassUID. Absent on a file that was not read from
+  // Part 10 bytes, so guard rather than assume.
+  const naturalMetaData = dicomData.meta
+    ? dcmjs.data.DicomMetaDictionary.naturalizeDataset(dicomData.meta)
+    : undefined
   mapResults.sourceInstanceUID = naturalData.SOPInstanceUID
 
   const finalSpec = composeSpecs(mappingOptions.curationSpec())
@@ -46,13 +52,19 @@ export default function collectMappings(
     finalSpec.dicomPS315EOptions,
     mappingOptions.columnMappings,
     finalSpec.additionalData,
+    naturalMetaData,
   )
 
-  // preExclude: original DICOM tags visible via parser.getDicom
+  // preExclude: original DICOM tags visible via parser.getDicom / parser.getMetaDicom
   let preExcludeError: string | undefined
   try {
     if (finalSpec.preExclude?.(parser)) {
       mapResults.excluded = 'pre'
+      // Name only, never the full path: anomalies are shared with the
+      // server-bound log, and the raw path is carried in fileInfo instead.
+      mapResults.anomalies.push(
+        `Skipped pre-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
+      )
       return [naturalData, mapResults]
     }
   } catch (e) {
@@ -157,7 +169,8 @@ export default function collectMappings(
     }
   }
 
-  // postExclude: output path is finalised; parser.getDicom() returns de-identified values
+  // postExclude: output path is finalised; parser.getDicom() returns de-identified
+  // values — but parser.getMetaDicom() still returns the original meta group.
   try {
     if (
       finalSpec.postExclude?.({
@@ -166,6 +179,9 @@ export default function collectMappings(
       })
     ) {
       mapResults.excluded = 'post'
+      mapResults.anomalies.push(
+        `Skipped post-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
+      )
       return [naturalData, mapResults]
     }
   } catch (e) {

--- a/src/collectMappings.ts
+++ b/src/collectMappings.ts
@@ -60,11 +60,18 @@ export default function collectMappings(
   try {
     if (finalSpec.preExclude?.(parser)) {
       mapResults.excluded = 'pre'
+      // Write pass only: collectMappings runs on both the form-generation pass
+      // (skipWrite) and the write pass, so emitting on both would double-count
+      // the file for anomaly consumers. Matches the benign scan-exclusion
+      // anomalies, which are likewise write-pass only.
+      //
       // Name only, never the full path: anomalies are shared with the
       // server-bound log, and the raw path is carried in fileInfo instead.
-      mapResults.anomalies.push(
-        `Skipped pre-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
-      )
+      if (!mappingOptions.skipWrite) {
+        mapResults.anomalies.push(
+          `Skipped pre-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
+        )
+      }
       return [naturalData, mapResults]
     }
   } catch (e) {
@@ -179,9 +186,12 @@ export default function collectMappings(
       })
     ) {
       mapResults.excluded = 'post'
-      mapResults.anomalies.push(
-        `Skipped post-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
-      )
+      // Write pass only — see the preExclude note above.
+      if (!mappingOptions.skipWrite) {
+        mapResults.anomalies.push(
+          `Skipped post-excluded file: ${parser.getFilePathComp(parser.FILENAME)}`,
+        )
+      }
       return [naturalData, mapResults]
     }
   } catch (e) {

--- a/src/curateOne.test.ts
+++ b/src/curateOne.test.ts
@@ -1,4 +1,9 @@
 import * as dcmjs from 'dcmjs'
+import { generateFile } from 'dicom-synth'
+import {
+  buildDicomdirDcmjsBuffer,
+  DICOMDIR_SOP_CLASS_UID,
+} from '../testutils/minimalDicom'
 import { curateOne } from './curateOne'
 import { hash } from './hash'
 import type {
@@ -1354,4 +1359,99 @@ describe('curateOne stream read failure during parse (regression #287)', () => {
 
     expect(unhandled).toEqual([])
   }, 10_000)
+})
+
+describe('curateOne DICOMDIR pre-exclusion', () => {
+  const inputPath =
+    'Sample_Protocol_Number/Sample_CRO/AB12-123/Visit 1/PET-Abdomen'
+
+  // A spec that excludes DICOMDIRs by media storage SOP class. The SOP class
+  // lives in the file meta group, so only getMetaDicom can see it.
+  const dicomdirExcludingSpec: () => TCurationSpecification = () => ({
+    inputPathPattern:
+      'protocolNumber/activityProvider/centerSubjectId/timepoint/scan',
+    version: '3.0',
+    hostProps: {},
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: (parser) => [
+      parser.getFilePathComp('protocolNumber'),
+      parser.getFilePathComp(parser.FILENAME),
+    ],
+    errors: () => [],
+    preExclude: (parser) =>
+      parser.getMetaDicom('MediaStorageSOPClassUID') === DICOMDIR_SOP_CLASS_UID,
+  })
+
+  function fileInfoFor(buffer: ArrayBuffer, name: string): TFileInfo {
+    return {
+      kind: 'blob',
+      blob: new Blob([buffer], { type: 'application/octet-stream' }),
+      path: inputPath,
+      name,
+      size: buffer.byteLength,
+    }
+  }
+
+  it('excludes a DICOMDIR carrying a .dcm extension and writes nothing', async () => {
+    const result = await curateOne({
+      // Named like an instance: filename-based exclusion cannot catch this.
+      fileInfo: fileInfoFor(buildDicomdirDcmjsBuffer(), 'IM000001.dcm'),
+      outputTarget: {},
+      mappingOptions: { curationSpec: dicomdirExcludingSpec, skipWrite: false },
+    })
+
+    expect(result.excluded).toBe('pre')
+    expect(result.mappedBlob).toBeUndefined()
+    expect(result.anomalies.join(' ')).toContain('IM000001.dcm')
+  })
+
+  it('cannot exclude a DICOMDIR that dcmjs rejects, but writes nothing', async () => {
+    // Known limitation: preExclude runs only after a successful parse. A
+    // DICOMDIR whose writer omitted the meta group length is rejected by dcmjs
+    // outright, so it is reported as a parse error rather than a clean
+    // exclusion. It is still never written to the output.
+    const { buffer } = await generateFile({ type: 'dicomdir' })
+
+    const result = await curateOne({
+      fileInfo: fileInfoFor(buffer.buffer as ArrayBuffer, 'IM000009.dcm'),
+      outputTarget: {},
+      mappingOptions: { curationSpec: dicomdirExcludingSpec, skipWrite: false },
+    })
+
+    expect(result.excluded).toBeUndefined()
+    expect(result.mappedBlob).toBeUndefined()
+    expect(result.errors?.join(' ')).toContain('not a valid DICOM file')
+  })
+
+  it('does not exclude an ordinary image instance', async () => {
+    const dataset = {
+      PatientName: 'Test',
+      PatientID: 'P001',
+      Modality: 'CT',
+      SOPClassUID: '1.2.840.10008.5.1.4.1.1.2',
+      SOPInstanceUID: '1.2.3.4.5.6.7.8.9',
+      SeriesInstanceUID: '1.2.3.4.5.6.7.8',
+      StudyInstanceUID: '1.2.3.4.5.6.7',
+      SeriesNumber: '1',
+    }
+    const dicomDict = new dcmjs.data.DicomDict({
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+      '00020002': { vr: 'UI', Value: [dataset.SOPClassUID] },
+      '00020003': { vr: 'UI', Value: [dataset.SOPInstanceUID] },
+    })
+    dicomDict.dict = dcmjs.data.DicomMetaDictionary.denaturalizeDataset(dataset)
+
+    const result = await curateOne({
+      fileInfo: fileInfoFor(
+        dicomDict.write({ allowInvalidVRLength: true }),
+        'IM000002.dcm',
+      ),
+      outputTarget: {},
+      mappingOptions: { curationSpec: dicomdirExcludingSpec, skipWrite: false },
+    })
+
+    expect(result.excluded).toBeUndefined()
+    expect(result.mappedBlob).toBeDefined()
+  })
 })

--- a/src/getParser.ts
+++ b/src/getParser.ts
@@ -15,6 +15,7 @@ export default function getParser(
   dicomPS315EOptions: TCurationSpecification['dicomPS315EOptions'],
   columnMappings?: TColumnMappings,
   additionalData?: TCurationSpecification['additionalData'],
+  naturalMetaData?: TNaturalData,
 ): TParser {
   function protectUid(uid: string): string {
     let protectedUid = uid
@@ -89,6 +90,24 @@ export default function getParser(
           }
         })()
 
+  // Reads the file meta information group (group 0002), which getDicom cannot
+  // see because it operates on the dataset alone. Needed to identify a file by
+  // MediaStorageSOPClassUID (e.g. for a DICOMDIR disguised as a .DCM).
+  //
+  // Values are always the ORIGINAL ones, even in postExclude where getDicom has
+  // already switched to de-identified values — the meta group is captured once
+  // and never re-read. Only string values are returned; a non-string meta value
+  // (e.g. the OB FileMetaInformationVersion) reads as undefined.
+  function getMetaDicom(attrName: string): string | undefined {
+    if (!naturalMetaData) return undefined
+    if (attrName in dcmjs.data.DicomMetaDictionary.dictionary) {
+      // if in hex like "(0002,0002)", convert to text key
+      attrName = dcmjs.data.DicomMetaDictionary.dictionary[attrName].name
+    }
+    const value = _get(naturalMetaData, attrName)
+    return typeof value === 'string' ? value : undefined
+  }
+
   function missingDicom(attrName: string) {
     const value = getDicom(attrName)
     return typeof value === 'undefined' || value === ''
@@ -99,6 +118,7 @@ export default function getParser(
     getFilePathComp,
     getMapping,
     getDicom,
+    getMetaDicom,
     missingDicom,
     protectUid,
     // TODO: Phase this out in favor of ISO8601 duration handling.

--- a/src/metaDicom.test.ts
+++ b/src/metaDicom.test.ts
@@ -1,0 +1,127 @@
+import type { TDicomData } from 'dcmjs'
+import { DICOMDIR_SOP_CLASS_UID } from '../testutils/minimalDicom'
+import collectMappings from './collectMappings'
+import type { TCurationSpecification, TMappingOptions, TParser } from './types'
+
+const CT_IMAGE_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.2'
+
+function makeSpec(
+  preExclude?: (parser: TParser) => boolean,
+): () => TCurationSpecification {
+  return () => ({
+    version: '3.0',
+    inputPathPattern: 'study/subject',
+    hostProps: {},
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: () => ['study', 'subject', 'test.dcm'],
+    errors: () => [],
+    ...(preExclude ? { preExclude } : {}),
+  })
+}
+
+/** A DICOMDIR declares its SOP class only in the file meta group. */
+function dicomdirData(): TDicomData {
+  return {
+    meta: {
+      '00020002': { vr: 'UI', Value: [DICOMDIR_SOP_CLASS_UID] },
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+    },
+    dict: {
+      '00041130': { vr: 'CS', Value: ['TESTFS'] },
+      '00041220': { vr: 'SQ', Value: [] },
+    },
+  } as unknown as TDicomData
+}
+
+function imageData(): TDicomData {
+  return {
+    meta: {
+      '00020002': { vr: 'UI', Value: [CT_IMAGE_SOP_CLASS_UID] },
+      '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+    },
+    dict: {
+      '00080016': { vr: 'UI', Value: [CT_IMAGE_SOP_CLASS_UID] },
+      '00080060': { vr: 'CS', Value: ['CT'] },
+    },
+  } as unknown as TDicomData
+}
+
+function run(
+  data: TDicomData,
+  preExclude?: (parser: TParser) => boolean,
+  inputFilePath = 'study/subject/test.dcm',
+) {
+  const mappingOptions: TMappingOptions = {
+    curationSpec: makeSpec(preExclude),
+  }
+  return collectMappings(inputFilePath, data, mappingOptions)
+}
+
+const excludeDicomdir = (parser: TParser) =>
+  parser.getMetaDicom('MediaStorageSOPClassUID') === DICOMDIR_SOP_CLASS_UID
+
+describe('parser.getMetaDicom', () => {
+  it('reads a tag from the file meta group', () => {
+    let seen: string | undefined
+    run(dicomdirData(), (parser) => {
+      seen = parser.getMetaDicom('MediaStorageSOPClassUID')
+      return false
+    })
+    expect(seen).toBe(DICOMDIR_SOP_CLASS_UID)
+  })
+
+  it('accepts a hex tag key', () => {
+    let seen: string | undefined
+    run(dicomdirData(), (parser) => {
+      seen = parser.getMetaDicom('(0002,0002)')
+      return false
+    })
+    expect(seen).toBe(DICOMDIR_SOP_CLASS_UID)
+  })
+
+  it('does not expose meta tags through getDicom', () => {
+    // getDicom sees the dataset only — this is why getMetaDicom exists.
+    let seen: unknown
+    run(dicomdirData(), (parser) => {
+      seen = parser.getDicom('MediaStorageSOPClassUID')
+      return false
+    })
+    expect(seen).toBeUndefined()
+  })
+
+  it('returns undefined when the meta group is absent', () => {
+    const noMeta = { dict: imageData().dict } as unknown as TDicomData
+    let seen: string | undefined
+    expect(() =>
+      run(noMeta, (parser) => {
+        seen = parser.getMetaDicom('MediaStorageSOPClassUID')
+        return false
+      }),
+    ).not.toThrow()
+    expect(seen).toBeUndefined()
+  })
+})
+
+describe('preExclude driven by media storage SOP class', () => {
+  it('excludes a DICOMDIR', () => {
+    const [, mapResults] = run(dicomdirData(), excludeDicomdir)
+    expect(mapResults.excluded).toBe('pre')
+  })
+
+  it('does not exclude an ordinary image instance', () => {
+    const [, mapResults] = run(imageData(), excludeDicomdir)
+    expect(mapResults.excluded).toBeUndefined()
+  })
+
+  it('records the excluded file by name, without the path', () => {
+    const [, mapResults] = run(
+      dicomdirData(),
+      excludeDicomdir,
+      'study/subject/test.dcm',
+    )
+    const anomaly = mapResults.anomalies.join(' ')
+    expect(anomaly).toContain('test.dcm')
+    expect(anomaly).not.toContain('study/subject')
+  })
+})

--- a/src/metaDicom.test.ts
+++ b/src/metaDicom.test.ts
@@ -51,9 +51,11 @@ function run(
   data: TDicomData,
   preExclude?: (parser: TParser) => boolean,
   inputFilePath = 'study/subject/test.dcm',
+  skipWrite = false,
 ) {
   const mappingOptions: TMappingOptions = {
     curationSpec: makeSpec(preExclude),
+    skipWrite,
   }
   return collectMappings(inputFilePath, data, mappingOptions)
 }
@@ -123,5 +125,19 @@ describe('preExclude driven by media storage SOP class', () => {
     const anomaly = mapResults.anomalies.join(' ')
     expect(anomaly).toContain('test.dcm')
     expect(anomaly).not.toContain('study/subject')
+  })
+
+  it('still excludes but emits no anomaly on the form-generation pass', () => {
+    // collectMappings runs on both the skipWrite (form-generation) pass and the
+    // write pass; the exclusion anomaly is emitted only on the write pass so
+    // consumers do not double-count the file.
+    const [, mapResults] = run(
+      dicomdirData(),
+      excludeDicomdir,
+      'study/subject/test.dcm',
+      true,
+    )
+    expect(mapResults.excluded).toBe('pre')
+    expect(mapResults.anomalies).toEqual([])
   })
 })

--- a/src/scanDirectoryWorker.ts
+++ b/src/scanDirectoryWorker.ts
@@ -13,6 +13,30 @@ const DEFAULT_EXCLUDED_FILETYPES = [
 ]
 
 /**
+ * Name-based exclusion decision for an S3 object key.
+ *
+ * Exported for testing: the S3 listing path needs a live bucket, and the worker
+ * runs in its own process where the S3 client cannot be mocked.
+ *
+ * Unlike the filesystem paths, an S3 key carries its whole prefix while the
+ * exclusion list holds bare filenames — and the defaults apply here too.
+ */
+export function isS3KeyExcludedByName(
+  key: string,
+  extraExcludedFiletypes: string[],
+  includeDefaults: boolean,
+): boolean {
+  const objectName = key.slice(key.lastIndexOf('/') + 1)
+  const allExcludedFiletypes = [
+    ...(includeDefaults ? DEFAULT_EXCLUDED_FILETYPES : []),
+    ...extraExcludedFiletypes,
+  ]
+  return allExcludedFiletypes.some(
+    (excluded) => objectName.toLowerCase() === excluded.toLowerCase(),
+  )
+}
+
+/**
  * Build a PHI-safe error message for a file that could not be read during
  * scanning. Only the error code/name is included — never `error.message`,
  * because node fs errors embed the full raw path in the message (e.g.
@@ -237,9 +261,7 @@ async function shouldProcessFileItem(
 
     // Check if the file is in the list of excluded files
     if (
-      excludedFiletypes.some(
-        (excluded) => s3Item.Key.toLowerCase() === excluded.toLowerCase(),
-      )
+      isS3KeyExcludedByName(s3Item.Key, excludedFiletypes, !noDefaultExclusions)
     ) {
       fileAnomalies.push(`Skipped excluded file: ${s3Item.Key}`)
       return false

--- a/src/scanExclusions.test.ts
+++ b/src/scanExclusions.test.ts
@@ -1,0 +1,40 @@
+import { isS3KeyExcludedByName } from './scanDirectoryWorker'
+
+describe('isS3KeyExcludedByName', () => {
+  it('excludes a default-excluded file listed under a prefix', () => {
+    // An S3 key carries its prefix; the exclusion list holds bare filenames.
+    expect(isS3KeyExcludedByName('study1/series2/DICOMDIR', [], true)).toBe(
+      true,
+    )
+    expect(isS3KeyExcludedByName('DICOMDIR', [], true)).toBe(true)
+  })
+
+  it('applies the default exclusions on the S3 path', () => {
+    // The defaults must apply to bucket scans, not just caller-supplied entries.
+    expect(isS3KeyExcludedByName('a/b/Thumbs.db', [], true)).toBe(true)
+    expect(isS3KeyExcludedByName('a/b/.DS_Store', [], true)).toBe(true)
+  })
+
+  it('honours noDefaultExclusions by omitting the defaults', () => {
+    expect(isS3KeyExcludedByName('study1/DICOMDIR', [], false)).toBe(false)
+  })
+
+  it('matches caller-supplied exclusions case-insensitively', () => {
+    expect(isS3KeyExcludedByName('a/NOTES.TXT', ['notes.txt'], false)).toBe(
+      true,
+    )
+  })
+
+  it('does not exclude ordinary instances', () => {
+    expect(isS3KeyExcludedByName('study1/IM000001.dcm', [], true)).toBe(false)
+  })
+
+  it('does not match on a partial filename', () => {
+    expect(isS3KeyExcludedByName('a/DICOMDIR.dcm', [], true)).toBe(false)
+    expect(isS3KeyExcludedByName('a/NOTDICOMDIR', [], true)).toBe(false)
+  })
+
+  it('handles a key with a trailing slash', () => {
+    expect(isS3KeyExcludedByName('study1/', [], true)).toBe(false)
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,6 +300,11 @@ export type TParser = {
   getFilePathComp: (component: string | number | symbol) => string
   getMapping: ((value: string) => string | number) | undefined
   getDicom: (attrName: string) => any
+  // Reads the file meta information group (group 0002) — not the dataset. Use
+  // for MediaStorageSOPClassUID, which is where a DICOMDIR declares its SOP class.
+  // Returns the ORIGINAL value even in postExclude, where getDicom has already
+  // switched to de-identified values. Non-string meta values read as undefined.
+  getMetaDicom: (attrName: string) => string | undefined
   missingDicom: (attrName: string) => boolean
   protectUid: (uid: string) => string
   addDays: (dicomDateString: string, offsetDays: number) => string

--- a/testutils/minimalDicom.ts
+++ b/testutils/minimalDicom.ts
@@ -37,6 +37,28 @@ export function writeMinimalDicomFile(
   writeFileSync(filePath, Buffer.from(buffer))
 }
 
+export const DICOMDIR_SOP_CLASS_UID = '1.2.840.10008.1.3.10'
+
+/**
+ * A DICOMDIR that dcmjs can parse, so it reaches `preExclude`.
+ *
+ * MediaStorageSOPClassUID must be written into the meta group explicitly —
+ * dcmjs does not derive it from the dataset's SOPClassUID.
+ */
+export function buildDicomdirDcmjsBuffer(): ArrayBuffer {
+  const dicomDict = new dcmjs.data.DicomDict({
+    '00020002': { vr: 'UI', Value: [DICOMDIR_SOP_CLASS_UID] },
+    '00020003': { vr: 'UI', Value: ['1.2.3.4.5.6.7.8.9'] },
+    '00020010': { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] },
+  })
+  // Basic Directory IOD: an empty file-set is still a valid DICOMDIR.
+  dicomDict.dict = dcmjs.data.DicomMetaDictionary.denaturalizeDataset({
+    FileSetID: 'TESTFS',
+    DirectoryRecordSequence: [],
+  })
+  return dicomDict.write({ allowInvalidVRLength: true })
+}
+
 export function writeNonDicomFile(
   filePath: string,
   content = 'not dicom',


### PR DESCRIPTION
expose dicom meta to facilitate (content-based) dicomdir exclusion via specs - e.g. pre/post exclude fields

Also fixes a bug where S3 scans never applied the default exclusions and matched whole keys instead of basenames