### PR TITLE
Test/integration csv mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
       - name: E2E smoke
         run: pnpm test:e2e
 
+      - name: Integration tests
+        run: pnpm test:integration
+
       - name: Cache public conformance fixtures
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ Other scripts:
 | Script | Purpose |
 |--------|---------|
 | `pnpm test:coverage` | Unit project with coverage |
+| `pnpm test:watch` | Unit project in watch mode (unit only — the other projects need a `dist/esm` build per change) |
 | `pnpm update:conformance-baselines` | Regenerate committed `dciodvfy` baseline JSON |
 
 Conformance tests require the external `dciodvfy` binary from [dicom3tools](https://www.dclunie.com/dicom3tools.html). See [conformance/README.md](conformance/README.md) for install, CI behaviour, baseline refresh, and optional `RUN_PUBLIC_CONFORMANCE` / `CONFORMANCE_LOCAL_*` env vars.

--- a/README.md
+++ b/README.md
@@ -438,13 +438,20 @@ result.excluded // => 'pre' | 'post' | undefined
 
 ## Testing
 
-Vitest is split into three projects in `vitest.config.ts`:
+Vitest is split into four projects in `vitest.config.ts`:
 
 | Command | Project | Location | Purpose |
 |---------|---------|----------|---------|
-| `pnpm test` | `unit` | `src/**/*.test.ts` | Unit and integration tests co-located with source |
+| `pnpm test` | `unit` | `src/**/*.test.ts` | Unit tests co-located with source (excludes `*.integration.test.ts`) |
+| `pnpm test:integration` | `integration` | `src/**/*.integration.test.ts` | Cross-module flows through real workers (runs `build:esm` first; uses `dist/`) |
 | `pnpm test:e2e` | `e2e` | `e2e/` | Pipeline smoke tests (runs `build:esm` first; uses `dist/`) |
 | `pnpm test:conformance` | `conformance` | `conformance/` | `dciodvfy` regression (synthetic; optional public/local via env) |
+
+`integration` and `e2e` both drive the real workers from `dist/esm`, since
+`curateMany` builds them from `new URL(...)` and has no injection seam. They
+differ in intent: `e2e` asserts the final outputs of the public API, while
+`integration` targets intermediate behaviour and failure handling (progress
+messages, concurrency, backpressure, abort).
 
 Other scripts:
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -10,18 +10,36 @@ export {
   type Workspace,
 } from '../testutils/workspace'
 
-import { assertInputOutputDisjoint } from '../testutils/workspace'
+import {
+  assertInputOutputDisjoint,
+  INPUT_DIR_NAME,
+} from '../testutils/workspace'
 
 export function createWorkspace() {
   return createSharedWorkspace('dicom-curate-e2e-')
 }
 
-/** Minimal spec: path-aware layout under study/subject/. */
+// The specs below hard-code `input/...` because spec functions are serialized
+// to the worker and cannot close over variables. Fail loudly if the workspace
+// layout ever stops matching that literal.
+if (INPUT_DIR_NAME !== 'input') {
+  throw new Error(
+    `e2e specs hard-code 'input/...' but INPUT_DIR_NAME is '${INPUT_DIR_NAME}'`,
+  )
+}
+
+/**
+ * Minimal spec: path-aware layout under study/subject/.
+ *
+ * The leading `input` is required: scanned paths are relative to the scan
+ * root's parent, so omitting it shifts every `getFilePathComp` lookup by one
+ * and silently returns the wrong segment rather than erroring.
+ */
 export function pathOrganizedSmokeSpec(): () => TCurationSpecification {
   return () => ({
     version: '3.0',
     hostProps: { protocolNumber: 'e2e-smoke' },
-    inputPathPattern: 'study/subject',
+    inputPathPattern: 'input/study/subject',
     dicomPS315EOptions: 'Off',
     modifyDicomHeader: () => ({}),
     outputFilePathComponents: (parser) => [
@@ -38,7 +56,7 @@ export function ps315SmokeSpec(): () => TCurationSpecification {
   return () => ({
     version: '3.0',
     hostProps: { protocolNumber: 'e2e-ps315' },
-    inputPathPattern: 'study/subject',
+    inputPathPattern: 'input/study/subject',
     dicomPS315EOptions: {
       cleanDescriptorsOption: true,
       cleanDescriptorsExceptions: false,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,94 +1,19 @@
-import { createHash } from 'node:crypto'
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-} from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join, relative, resolve, sep } from 'node:path'
 import type { OrganizeOptions, TCurationSpecification } from '../src/types'
+import { createWorkspace as createSharedWorkspace } from '../testutils/workspace'
 
-/** Fail fast when input and output trees could collide. */
-export function assertInputOutputDisjoint(
-  inputDir: string,
-  outputDir: string,
-): void {
-  const input = resolve(inputDir)
-  const output = resolve(outputDir)
-  if (
-    input === output ||
-    input.startsWith(output + sep) ||
-    output.startsWith(input + sep)
-  ) {
-    throw new Error(
-      `Input and output directories must not overlap (input=${input}, output=${output})`,
-    )
-  }
-}
+// Workspace and directory helpers are shared with the integration suite; see
+// testutils/workspace.ts.
+export {
+  assertInputOutputDisjoint,
+  hashDirectoryFiles,
+  listFilesRecursive,
+  type Workspace,
+} from '../testutils/workspace'
 
-export function createWorkspace(): {
-  inputDir: string
-  outputDir: string
-  cleanup: () => void
-} {
-  const base = mkdtempSync(join(tmpdir(), 'dicom-curate-e2e-'))
-  const inputDir = join(base, 'input')
-  const outputDir = join(base, 'output')
-  mkdirSync(inputDir, { recursive: true })
-  mkdirSync(outputDir, { recursive: true })
-  assertInputOutputDisjoint(inputDir, outputDir)
-  return {
-    inputDir,
-    outputDir,
-    cleanup: () => {
-      if (existsSync(base)) {
-        rmSync(base, { recursive: true, force: true })
-      }
-    },
-  }
-}
+import { assertInputOutputDisjoint } from '../testutils/workspace'
 
-export function hashDirectoryFiles(root: string): Map<string, string> {
-  const hashes = new Map<string, string>()
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name)
-      if (entry.isDirectory()) {
-        walk(full)
-      } else {
-        const rel = relative(root, full)
-        const digest = createHash('sha256')
-          .update(readFileSync(full))
-          .digest('hex')
-        hashes.set(rel, digest)
-      }
-    }
-  }
-  if (existsSync(root)) {
-    walk(root)
-  }
-  return hashes
-}
-
-export function listFilesRecursive(root: string): string[] {
-  const files: string[] = []
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name)
-      if (entry.isDirectory()) {
-        walk(full)
-      } else {
-        files.push(relative(root, full))
-      }
-    }
-  }
-  if (existsSync(root)) {
-    walk(root)
-  }
-  return files.sort()
+export function createWorkspace() {
+  return createSharedWorkspace('dicom-curate-e2e-')
 }
 
 /** Minimal spec: path-aware layout under study/subject/. */

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -172,10 +172,18 @@ describe('E2E smoke: curateMany', () => {
     )
     expect(withAnomalies.length).toBeGreaterThanOrEqual(2)
 
-    const validResult = (result.mapResultsList ?? []).find((r) =>
-      r.outputFilePath?.includes('valid.dcm'),
+    // Match on the source name: the leaf is renamed to <Modality>_<UID>.dcm,
+    // so matching outputFilePath on 'valid.dcm' silently finds nothing.
+    const validResult = (result.mapResultsList ?? []).find(
+      (r) => r.fileInfo?.name === 'valid.dcm',
     )
+    expect(validResult).toBeDefined()
     expect(validResult?.errors ?? []).toEqual([])
+    // Pins the spec's inputPathPattern: a pattern missing the input dir
+    // basename shifts every lookup by one and lands this under 'study'.
+    expect(validResult?.outputFilePath).toMatch(
+      /^curated\/subject\/CT_.+\.dcm$/,
+    )
 
     expect(
       listFilesRecursive(outputDir).filter((p) => p.endsWith('.dcm')),
@@ -219,9 +227,11 @@ describe('E2E smoke: curateMany', () => {
       // The run completes despite the unreadable file, and the readable file
       // is fully processed.
       expect(result.response).toBe('done')
-      const validResult = (result.mapResultsList ?? []).find((r) =>
-        r.outputFilePath?.includes('valid.dcm'),
+      // By source name, not output path — see the note in the anomalies test.
+      const validResult = (result.mapResultsList ?? []).find(
+        (r) => r.fileInfo?.name === 'valid.dcm',
       )
+      expect(validResult).toBeDefined()
       expect(validResult?.errors ?? []).toEqual([])
 
       const readErrorResults = (result.mapResultsList ?? []).filter(

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pretest": "pnpm build:esm",
     "test": "vitest run --pool=forks --project unit",
     "test:e2e": "pnpm build:esm && vitest run --pool=forks --project e2e",
+    "test:integration": "pnpm build:esm && vitest run --pool=forks --project integration",
     "test:conformance": "vitest run --pool=forks --project conformance",
     "update:conformance-baselines": "esbuild scripts/update-conformance-baselines.ts --bundle --platform=node --format=esm --external:dicom-synth --outfile=conformance/.update-conformance-baselines.mjs && node conformance/.update-conformance-baselines.mjs",
     "test:coverage": "vitest run --pool=forks --project unit --coverage",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:conformance": "vitest run --pool=forks --project conformance",
     "update:conformance-baselines": "esbuild scripts/update-conformance-baselines.ts --bundle --platform=node --format=esm --external:dicom-synth --outfile=conformance/.update-conformance-baselines.mjs && node conformance/.update-conformance-baselines.mjs",
     "test:coverage": "vitest run --pool=forks --project unit --coverage",
-    "test:watch": "vitest",
+    "test:watch": "vitest --project unit",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "prepare": "husky install && pnpm build",

--- a/src/csvMapping.integration.test.ts
+++ b/src/csvMapping.integration.test.ts
@@ -16,8 +16,7 @@ import {
   writeImages,
 } from '../testutils/integrationHarness'
 
-/** `writeImages` assigns PatientID `PID-0000`, `PID-0001`, … in order. */
-const sourceId = (i: number) => `PID-${String(i).padStart(4, '0')}`
+/** Target ids this suite maps onto; source ids come from `writeImages`. */
 const mappedId = (i: number) => `NEW-${String(i).padStart(4, '0')}`
 
 describe('two-pass CSV mapping through real workers', () => {
@@ -38,10 +37,10 @@ describe('two-pass CSV mapping through real workers', () => {
   it('binds each CSV row to its own file across a concurrent batch', async () => {
     const { inputDir, outputDir } = workspace()
     const count = 12
-    await writeImages(inputDir, count)
+    const written = await writeImages(inputDir, count)
 
-    const table = Array.from({ length: count }, (_, i) => ({
-      oldId: sourceId(i),
+    const table = written.map((w, i) => ({
+      oldId: w.patientId,
       newId: mappedId(i),
     }))
 
@@ -83,10 +82,10 @@ describe('two-pass CSV mapping through real workers', () => {
     const { inputDir, outputDir } = workspace()
     const count = 6
     const mappedCount = 4
-    await writeImages(inputDir, count)
+    const written = await writeImages(inputDir, count)
 
-    const table = Array.from({ length: mappedCount }, (_, i) => ({
-      oldId: sourceId(i),
+    const table = written.slice(0, mappedCount).map((w, i) => ({
+      oldId: w.patientId,
       newId: mappedId(i),
     }))
 

--- a/src/csvMapping.integration.test.ts
+++ b/src/csvMapping.integration.test.ts
@@ -1,5 +1,9 @@
 /**
- * Two-pass CSV mapping (strategy W2) driven through `curateMany`.
+ * Direct CSV-load mapping (`additionalData.type: 'load'`) driven through
+ * `curateMany` — a caller-supplied `table` joined per file.
+ *
+ * NOT the two-pass flow: that is `type: 'listing'`, which derives its mapping
+ * from a first read-only pass.
  *
  * `applyMappingsWorker.test.ts` already exercises the mapping worker against a
  * real worker, but one file per run — so it cannot detect mis-attribution. The
@@ -7,32 +11,19 @@
  * its own file when several workers process the batch concurrently.
  */
 import {
-  createIntegrationWorkspace,
   csvMappingSpec,
-  type IntegrationWorkspace,
   integrationOptions,
   listFilesRecursive,
   runCapturingProgress,
+  useWorkspaces,
   writeImages,
 } from '../testutils/integrationHarness'
 
 /** Target ids this suite maps onto; source ids come from `writeImages`. */
 const mappedId = (i: number) => `NEW-${String(i).padStart(4, '0')}`
 
-describe('two-pass CSV mapping through real workers', () => {
-  const workspaces: IntegrationWorkspace[] = []
-
-  afterEach(() => {
-    for (const w of workspaces.splice(0)) {
-      w.cleanup()
-    }
-  })
-
-  function workspace(): IntegrationWorkspace {
-    const w = createIntegrationWorkspace()
-    workspaces.push(w)
-    return w
-  }
+describe('direct CSV-load mapping through real workers', () => {
+  const workspace = useWorkspaces()
 
   it('binds each CSV row to its own file across a concurrent batch', async () => {
     const { inputDir, outputDir } = workspace()

--- a/src/csvMapping.integration.test.ts
+++ b/src/csvMapping.integration.test.ts
@@ -53,20 +53,20 @@ describe('direct CSV-load mapping through real workers', () => {
 
     // The join must be per-file: every source id maps to its own new id, and
     // concurrency must not shuffle rows between files.
-    const pairs = results
-      .map((r) => {
+    //
+    // Keyed on fileInfo.name because a result's `from` and `to` both come from
+    // the same parser — comparing them to each other passes even when the
+    // result is attributed to the wrong file.
+    const expected = new Map(
+      written.map((w, i) => [w.name, { from: w.patientId, to: mappedId(i) }]),
+    )
+    const actual = new Map(
+      results.map((r) => {
         const mapping = r.mappings?.PatientID
-        return { from: mapping?.[0], to: mapping?.[3] }
-      })
-      .filter((p) => typeof p.from === 'string')
-    expect(pairs).toHaveLength(count)
-
-    const expected = new Map(table.map((row) => [row.oldId, row.newId]))
-    for (const { from, to } of pairs) {
-      expect(to).toBe(expected.get(String(from)))
-    }
-    // Every row was consumed exactly once — no duplicates, none skipped.
-    expect(new Set(pairs.map((p) => p.to)).size).toBe(count)
+        return [r.fileInfo?.name, { from: mapping?.[0], to: mapping?.[3] }]
+      }),
+    )
+    expect(actual).toEqual(expected)
   })
 
   it('fails only the unmapped files and still writes the mapped ones', async () => {
@@ -93,8 +93,20 @@ describe('direct CSV-load mapping through real workers', () => {
     const failed = results.filter((r) => (r.errors ?? []).length > 0)
     const succeeded = results.filter((r) => (r.errors ?? []).length === 0)
 
-    expect(succeeded).toHaveLength(mappedCount)
-    expect(failed).toHaveLength(count - mappedCount)
+    // Which files failed, not just how many: the unmapped ones and only those.
+    const names = (rs: typeof results) => rs.map((r) => r.fileInfo?.name).sort()
+    expect(names(succeeded)).toEqual(
+      written
+        .slice(0, mappedCount)
+        .map((w) => w.name)
+        .sort(),
+    )
+    expect(names(failed)).toEqual(
+      written
+        .slice(mappedCount)
+        .map((w) => w.name)
+        .sort(),
+    )
 
     // Partial coverage is a per-file failure, not a run failure.
     expect(result.response).toBe('done')

--- a/src/csvMapping.integration.test.ts
+++ b/src/csvMapping.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Two-pass CSV mapping (strategy W2) driven through `curateMany`.
+ *
+ * `applyMappingsWorker.test.ts` already exercises the mapping worker against a
+ * real worker, but one file per run — so it cannot detect mis-attribution. The
+ * property that matters here is that a multi-file join keeps each row bound to
+ * its own file when several workers process the batch concurrently.
+ */
+import {
+  createIntegrationWorkspace,
+  csvMappingSpec,
+  type IntegrationWorkspace,
+  integrationOptions,
+  listFilesRecursive,
+  runCapturingProgress,
+  writeImages,
+} from '../testutils/integrationHarness'
+
+/** `writeImages` assigns PatientID `PID-0000`, `PID-0001`, … in order. */
+const sourceId = (i: number) => `PID-${String(i).padStart(4, '0')}`
+const mappedId = (i: number) => `NEW-${String(i).padStart(4, '0')}`
+
+describe('two-pass CSV mapping through real workers', () => {
+  const workspaces: IntegrationWorkspace[] = []
+
+  afterEach(() => {
+    for (const w of workspaces.splice(0)) {
+      w.cleanup()
+    }
+  })
+
+  function workspace(): IntegrationWorkspace {
+    const w = createIntegrationWorkspace()
+    workspaces.push(w)
+    return w
+  }
+
+  it('binds each CSV row to its own file across a concurrent batch', async () => {
+    const { inputDir, outputDir } = workspace()
+    const count = 12
+    await writeImages(inputDir, count)
+
+    const table = Array.from({ length: count }, (_, i) => ({
+      oldId: sourceId(i),
+      newId: mappedId(i),
+    }))
+
+    const { result } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, csvMappingSpec(), {
+        workerCount: 3,
+        table,
+      }),
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(count)
+
+    const results = result.mapResultsList ?? []
+    expect(results).toHaveLength(count)
+    for (const r of results) {
+      expect(r.errors ?? []).toEqual([])
+    }
+
+    // The join must be per-file: every source id maps to its own new id, and
+    // concurrency must not shuffle rows between files.
+    const pairs = results
+      .map((r) => {
+        const mapping = r.mappings?.PatientID
+        return { from: mapping?.[0], to: mapping?.[3] }
+      })
+      .filter((p) => typeof p.from === 'string')
+    expect(pairs).toHaveLength(count)
+
+    const expected = new Map(table.map((row) => [row.oldId, row.newId]))
+    for (const { from, to } of pairs) {
+      expect(to).toBe(expected.get(String(from)))
+    }
+    // Every row was consumed exactly once — no duplicates, none skipped.
+    expect(new Set(pairs.map((p) => p.to)).size).toBe(count)
+  })
+
+  it('fails only the unmapped files and still writes the mapped ones', async () => {
+    const { inputDir, outputDir } = workspace()
+    const count = 6
+    const mappedCount = 4
+    await writeImages(inputDir, count)
+
+    const table = Array.from({ length: mappedCount }, (_, i) => ({
+      oldId: sourceId(i),
+      newId: mappedId(i),
+    }))
+
+    const { result } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, csvMappingSpec(), {
+        workerCount: 2,
+        table,
+      }),
+    )
+
+    const results = result.mapResultsList ?? []
+    expect(results).toHaveLength(count)
+
+    const failed = results.filter((r) => (r.errors ?? []).length > 0)
+    const succeeded = results.filter((r) => (r.errors ?? []).length === 0)
+
+    expect(succeeded).toHaveLength(mappedCount)
+    expect(failed).toHaveLength(count - mappedCount)
+
+    // Partial coverage is a per-file failure, not a run failure.
+    expect(result.response).toBe('done')
+    for (const r of failed) {
+      expect(r.errors.join(' ')).toMatch(/No row for/)
+      // Falsy rather than undefined: a mapping failure leaves outputFilePath as
+      // '' here, whereas a scan read failure leaves it undefined. Either way
+      // nothing is written — asserted on disk below, which is the guarantee
+      // that actually matters.
+      expect(r.outputFilePath).toBeFalsy()
+    }
+    for (const r of succeeded) {
+      expect(r.mappings?.PatientID?.[3]).toMatch(/^NEW-\d{4}$/)
+    }
+
+    expect(listFilesRecursive(outputDir)).toHaveLength(mappedCount)
+  })
+})

--- a/src/curateDict.dateOffsets.test.ts
+++ b/src/curateDict.dateOffsets.test.ts
@@ -3,7 +3,7 @@ import * as dcmjs from 'dcmjs'
 import curateDict from './curateDict'
 import type { TMappingOptions } from './types'
 
-describe('Integration tests: Date offsets should only affect instance data, not scanner data', () => {
+describe('curateDict: date offsets should only affect instance data, not scanner data', () => {
   // Test DICOM data with both instance and scanner dates
   const originalCalibrationDate = '20220301'
   const originalManufactureDate = '20200815'

--- a/src/curateMany.integration.test.ts
+++ b/src/curateMany.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Seed tests for the `integration` project — see testutils/integrationHarness.ts.
+ *
+ * These assert intermediate behaviour observable only with real workers: that
+ * the scan and mapping workers actually round-trip, and that per-file results
+ * reach the caller through the progress stream as work proceeds rather than
+ * only in the final result.
+ */
+import { join } from 'node:path'
+import {
+  createIntegrationWorkspace,
+  type IntegrationWorkspace,
+  integrationOptions,
+  integrationSpec,
+  runCapturingProgress,
+  writeImage,
+} from '../testutils/integrationHarness'
+
+describe('curateMany driven through real workers', () => {
+  const workspaces: IntegrationWorkspace[] = []
+
+  afterEach(() => {
+    for (const w of workspaces.splice(0)) {
+      w.cleanup()
+    }
+  })
+
+  function workspace(): IntegrationWorkspace {
+    const w = createIntegrationWorkspace()
+    workspaces.push(w)
+    return w
+  }
+
+  it('reports progress incrementally before the run completes', async () => {
+    const { inputDir, outputDir } = workspace()
+    for (const n of ['a', 'b', 'c']) {
+      await writeImage(join(inputDir, 'study', 'subject', `${n}.dcm`))
+    }
+
+    const { result, progress } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec()),
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(3)
+
+    // The point of this layer: work is observable while in flight, which only
+    // holds when the workers genuinely round-trip.
+    const beforeDone = progress.slice(
+      0,
+      progress.findIndex((m) => m.response === 'done'),
+    )
+    expect(beforeDone.length).toBeGreaterThan(0)
+    expect(beforeDone.every((m) => m.response === 'progress')).toBe(true)
+
+    const counts = beforeDone
+      .map((m) => m.processedFiles)
+      .filter((n): n is number => typeof n === 'number')
+    expect(counts).toEqual([...counts].sort((a, b) => a - b))
+  })
+
+  it('surfaces per-file mapping results through the progress stream', async () => {
+    const { inputDir, outputDir } = workspace()
+    await writeImage(join(inputDir, 'study', 'subject', 'only.dcm'), {
+      PatientID: 'INTEGRATION-PID',
+    })
+
+    const { result, progress } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec()),
+    )
+
+    expect(result.response).toBe('done')
+
+    const perFile = progress.flatMap((m) =>
+      m.response === 'progress' && m.mapResults ? [m.mapResults] : [],
+    )
+    expect(perFile).toHaveLength(1)
+    const mapped = perFile[0]
+    expect(mapped?.errors ?? []).toEqual([])
+
+    // The source filename is deliberately NOT preserved. With de-identification
+    // off and the output path differing from the input path, collectMappings
+    // renames the leaf to `<Modality>_<sourceInstanceUID>.dcm` so that
+    // restructuring two trees into one cannot collide.
+    expect(mapped?.outputFilePath).toMatch(/^curated\//)
+    expect(mapped?.outputFilePath).toBe(
+      `curated/study/CT_${mapped?.sourceInstanceUID}.dcm`,
+    )
+
+    // The same result is also accumulated into the terminal message, so a
+    // consumer can rely on either path.
+    expect(result.mapResultsList).toHaveLength(1)
+    expect(result.mapResultsList?.[0]?.outputFilePath).toBe(
+      mapped?.outputFilePath,
+    )
+  })
+})

--- a/src/curateMany.integration.test.ts
+++ b/src/curateMany.integration.test.ts
@@ -39,10 +39,10 @@ describe('curateMany driven through real workers', () => {
 
     // The point of this layer: work is observable while in flight, which only
     // holds when the workers genuinely round-trip.
-    const beforeDone = progress.slice(
-      0,
-      progress.findIndex((m) => m.response === 'done'),
-    )
+    const doneIndex = progress.findIndex((m) => m.response === 'done')
+    // Guard the slice below: -1 would silently drop the last message instead.
+    expect(doneIndex).toBeGreaterThan(-1)
+    const beforeDone = progress.slice(0, doneIndex)
     expect(beforeDone.length).toBeGreaterThan(0)
     expect(beforeDone.every((m) => m.response === 'progress')).toBe(true)
 

--- a/src/curateMany.integration.test.ts
+++ b/src/curateMany.integration.test.ts
@@ -13,8 +13,8 @@ import {
   integrationOptions,
   integrationSpec,
   runCapturingProgress,
-  writeImage,
 } from '../testutils/integrationHarness'
+import { VALID_CT_IMAGE, writeSynthFile } from '../testutils/synthFixtures'
 
 describe('curateMany driven through real workers', () => {
   const workspaces: IntegrationWorkspace[] = []
@@ -33,8 +33,14 @@ describe('curateMany driven through real workers', () => {
 
   it('reports progress incrementally before the run completes', async () => {
     const { inputDir, outputDir } = workspace()
-    for (const n of ['a', 'b', 'c']) {
-      await writeImage(join(inputDir, 'study', 'subject', `${n}.dcm`))
+    // Distinct index per file: output filenames derive from SOPInstanceUID, so
+    // identical instances would collapse onto a single output path.
+    for (const [i, n] of ['a', 'b', 'c'].entries()) {
+      await writeSynthFile(
+        join(inputDir, 'study', 'subject', `${n}.dcm`),
+        VALID_CT_IMAGE,
+        { index: i },
+      )
     }
 
     const { result, progress } = await runCapturingProgress(
@@ -61,8 +67,9 @@ describe('curateMany driven through real workers', () => {
 
   it('surfaces per-file mapping results through the progress stream', async () => {
     const { inputDir, outputDir } = workspace()
-    await writeImage(join(inputDir, 'study', 'subject', 'only.dcm'), {
-      PatientID: 'INTEGRATION-PID',
+    await writeSynthFile(join(inputDir, 'study', 'subject', 'only.dcm'), {
+      ...VALID_CT_IMAGE,
+      tags: { PatientID: 'INTEGRATION-PID' },
     })
 
     const { result, progress } = await runCapturingProgress(

--- a/src/curateMany.integration.test.ts
+++ b/src/curateMany.integration.test.ts
@@ -8,28 +8,15 @@
  */
 import { join } from 'node:path'
 import {
-  createIntegrationWorkspace,
-  type IntegrationWorkspace,
   integrationOptions,
   integrationSpec,
   runCapturingProgress,
+  useWorkspaces,
 } from '../testutils/integrationHarness'
 import { VALID_CT_IMAGE, writeSynthFile } from '../testutils/synthFixtures'
 
 describe('curateMany driven through real workers', () => {
-  const workspaces: IntegrationWorkspace[] = []
-
-  afterEach(() => {
-    for (const w of workspaces.splice(0)) {
-      w.cleanup()
-    }
-  })
-
-  function workspace(): IntegrationWorkspace {
-    const w = createIntegrationWorkspace()
-    workspaces.push(w)
-    return w
-  }
+  const workspace = useWorkspaces()
 
   it('reports progress incrementally before the run completes', async () => {
     const { inputDir, outputDir } = workspace()
@@ -88,10 +75,10 @@ describe('curateMany driven through real workers', () => {
     // The source filename is deliberately NOT preserved. With de-identification
     // off and the output path differing from the input path, collectMappings
     // renames the leaf to `<Modality>_<sourceInstanceUID>.dcm` so that
-    // restructuring two trees into one cannot collide.
-    expect(mapped?.outputFilePath).toMatch(/^curated\//)
+    // restructuring two trees into one cannot collide. The 'subject' segment
+    // confirms getFilePathComp resolved against the right path component.
     expect(mapped?.outputFilePath).toBe(
-      `curated/study/CT_${mapped?.sourceInstanceUID}.dcm`,
+      `curated/subject/CT_${mapped?.sourceInstanceUID}.dcm`,
     )
 
     // The same result is also accumulated into the terminal message, so a

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -7,32 +7,16 @@
  * exercises `workerCount > 1`, and the scan worker's 'stop'/'resume'
  * backpressure round-trip is driven by `index.ts` against a live worker.
  */
-import { readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
 import {
   createIntegrationWorkspace,
   type IntegrationWorkspace,
   integrationOptions,
   integrationSpec,
+  listFilesRecursive,
   runCapturingProgress,
   runExpectingRejection,
   writeImages,
 } from '../testutils/integrationHarness'
-
-/** Every file under `dir`, recursively, as paths relative to `dir`. */
-function listFiles(dir: string, prefix = ''): string[] {
-  const out: string[] = []
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    const rel = prefix ? `${prefix}/${entry}` : entry
-    if (statSync(full).isDirectory()) {
-      out.push(...listFiles(full, rel))
-    } else {
-      out.push(rel)
-    }
-  }
-  return out
-}
 
 describe('curateMany orchestration with real workers', () => {
   const workspaces: IntegrationWorkspace[] = []
@@ -71,7 +55,7 @@ describe('curateMany orchestration with real workers', () => {
       (r) => r.outputFilePath,
     )
     expect(new Set(outputPaths).size).toBe(count)
-    expect(listFiles(outputDir)).toHaveLength(count)
+    expect(listFilesRecursive(outputDir)).toHaveLength(count)
 
     // Each source file is represented exactly once.
     const patientIds = (result.mapResultsList ?? [])
@@ -97,7 +81,7 @@ describe('curateMany orchestration with real workers', () => {
 
     expect(result.response).toBe('done')
     expect(result.processedFiles).toBe(count)
-    expect(listFiles(outputDir)).toHaveLength(count)
+    expect(listFilesRecursive(outputDir)).toHaveLength(count)
 
     // The count must never overshoot the discovered total, in any message —
     // a pause/resume that lost or replayed a file would break this.
@@ -152,6 +136,6 @@ describe('curateMany orchestration with real workers', () => {
 
     expect(result.response).toBe('done')
     expect(result.processedFiles).toBe(count)
-    expect(listFiles(outputDir)).toHaveLength(count)
+    expect(listFilesRecursive(outputDir)).toHaveLength(count)
   })
 })

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -45,10 +45,10 @@ describe('curateMany orchestration with real workers', () => {
     expect(listFilesRecursive(outputDir)).toHaveLength(count)
 
     // Each source file is represented exactly once.
-    const patientIds = (result.mapResultsList ?? [])
+    const sourceNames = (result.mapResultsList ?? [])
       .map((r) => r.fileInfo?.name)
       .filter((n): n is string => typeof n === 'string')
-    expect(new Set(patientIds).size).toBe(count)
+    expect(new Set(sourceNames).size).toBe(count)
   })
 
   it('completes correctly on a queue deep enough to trigger scan backpressure', async () => {
@@ -116,11 +116,14 @@ describe('curateMany orchestration with real workers', () => {
     // Real workers were hard-terminated. A fresh run over the same input must
     // still complete — partial output from the aborted run is re-processed.
     //
-    // KNOWN RACE: mappingWorkerPool holds its state at module level and the
-    // next run resets `aborted` to false. A message still in flight from a
+    // KNOWN RACE (#302): mappingWorkerPool holds its state at module level and
+    // the next run resets `aborted` to false. A message still in flight from a
     // terminated run-1 worker can therefore pass the `if (aborted) return`
-    // guard and mutate run-2 counters. If this assertion ever flakes, that is
-    // the cause — it is a product bug, not a test bug.
+    // guard in the message handler and act on run-2 state — not just the
+    // counters, but pushing the terminated worker back onto
+    // availableMappingWorkers, so run 2 may dispatch to a dead thread and
+    // stall. If this assertion ever flakes, that is the cause — it is a
+    // product bug, not a test bug.
     const { result } = await runCapturingProgress(
       integrationOptions(inputDir, outputDir, integrationSpec(), {
         workerCount: 2,

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Orchestration behaviour that only real workers can demonstrate.
+ *
+ * The mock-worker suites (workerCrashRecovery, abortSignal, scannerCounting,
+ * mappingWorkerPool) already cover the logic of crash recovery, abort and
+ * counting. What they cannot cover is real thread scheduling: no test anywhere
+ * exercises `workerCount > 1`, and the scan worker's 'stop'/'resume'
+ * backpressure round-trip is driven by `index.ts` against a live worker.
+ */
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  createIntegrationWorkspace,
+  type IntegrationWorkspace,
+  integrationOptions,
+  integrationSpec,
+  runCapturingProgress,
+  runExpectingRejection,
+  writeImages,
+} from '../testutils/integrationHarness'
+
+/** Every file under `dir`, recursively, as paths relative to `dir`. */
+function listFiles(dir: string, prefix = ''): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const rel = prefix ? `${prefix}/${entry}` : entry
+    if (statSync(full).isDirectory()) {
+      out.push(...listFiles(full, rel))
+    } else {
+      out.push(rel)
+    }
+  }
+  return out
+}
+
+describe('curateMany orchestration with real workers', () => {
+  const workspaces: IntegrationWorkspace[] = []
+
+  afterEach(() => {
+    for (const w of workspaces.splice(0)) {
+      w.cleanup()
+    }
+  })
+
+  function workspace(): IntegrationWorkspace {
+    const w = createIntegrationWorkspace()
+    workspaces.push(w)
+    return w
+  }
+
+  it('processes every file exactly once across a pool of four workers', async () => {
+    const { inputDir, outputDir } = workspace()
+    const count = 40
+    await writeImages(inputDir, count)
+
+    const { result } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec(), {
+        workerCount: 4,
+      }),
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(count)
+    expect(result.mapResultsList).toHaveLength(count)
+
+    // Nothing dropped and nothing double-written: output paths are the
+    // collision-avoiding <Modality>_<sourceInstanceUID>.dcm, so a duplicate
+    // would collapse two results onto one path.
+    const outputPaths = (result.mapResultsList ?? []).map(
+      (r) => r.outputFilePath,
+    )
+    expect(new Set(outputPaths).size).toBe(count)
+    expect(listFiles(outputDir)).toHaveLength(count)
+
+    // Each source file is represented exactly once.
+    const patientIds = (result.mapResultsList ?? [])
+      .map((r) => r.fileInfo?.name)
+      .filter((n): n is string => typeof n === 'string')
+    expect(new Set(patientIds).size).toBe(count)
+  })
+
+  it('completes correctly on a queue deep enough to trigger scan backpressure', async () => {
+    const { inputDir, outputDir } = workspace()
+    // index.ts pauses the scan worker above a HIGH_WATER_MARK of 100 queued
+    // files and resumes on drain. 'stop'/'resume' are not observable from
+    // outside, so this asserts correctness under conditions that provoke the
+    // round-trip rather than asserting the messages themselves.
+    const count = 250
+    await writeImages(inputDir, count)
+
+    const { result, progress } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec(), {
+        workerCount: 1,
+      }),
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(count)
+    expect(listFiles(outputDir)).toHaveLength(count)
+
+    // The count must never overshoot the discovered total, in any message —
+    // a pause/resume that lost or replayed a file would break this.
+    for (const msg of progress) {
+      if (
+        typeof msg.processedFiles === 'number' &&
+        typeof msg.totalFiles === 'number'
+      ) {
+        expect(msg.processedFiles).toBeLessThanOrEqual(msg.totalFiles)
+      }
+    }
+  })
+
+  it('aborts a live run and leaves the input reusable by the next run', async () => {
+    const { inputDir, outputDir } = workspace()
+    const count = 120
+    await writeImages(inputDir, count)
+
+    const controller = new AbortController()
+    // Abort on the first file actually processed, not on a timer — otherwise
+    // whether work was in flight is a race, and the mock suite already covers
+    // aborting before startup.
+    const { progress, error } = await runExpectingRejection(
+      integrationOptions(inputDir, outputDir, integrationSpec(), {
+        workerCount: 2,
+        signal: controller.signal,
+      }),
+      (msg) => {
+        if (
+          !controller.signal.aborted &&
+          msg.response === 'progress' &&
+          (msg.processedFiles ?? 0) >= 1
+        ) {
+          controller.abort()
+        }
+      },
+    )
+
+    expect(error).toMatchObject({ name: 'AbortError' })
+    // Confirms the run really was mid-flight when aborted, and that it did not
+    // silently run to completion.
+    expect(progress.some((m) => (m.processedFiles ?? 0) >= 1)).toBe(true)
+    expect(progress.some((m) => m.response === 'done')).toBe(false)
+
+    // Real workers were hard-terminated. A fresh run over the same input must
+    // still complete — partial output from the aborted run is re-processed.
+    const { result } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec(), {
+        workerCount: 2,
+      }),
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(count)
+    expect(listFiles(outputDir)).toHaveLength(count)
+  })
+})

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -8,30 +8,17 @@
  * backpressure round-trip is driven by `index.ts` against a live worker.
  */
 import {
-  createIntegrationWorkspace,
-  type IntegrationWorkspace,
   integrationOptions,
   integrationSpec,
   listFilesRecursive,
   runCapturingProgress,
   runExpectingRejection,
+  useWorkspaces,
   writeImages,
 } from '../testutils/integrationHarness'
 
 describe('curateMany orchestration with real workers', () => {
-  const workspaces: IntegrationWorkspace[] = []
-
-  afterEach(() => {
-    for (const w of workspaces.splice(0)) {
-      w.cleanup()
-    }
-  })
-
-  function workspace(): IntegrationWorkspace {
-    const w = createIntegrationWorkspace()
-    workspaces.push(w)
-    return w
-  }
+  const workspace = useWorkspaces()
 
   it('processes every file exactly once across a pool of four workers', async () => {
     const { inputDir, outputDir } = workspace()
@@ -128,6 +115,12 @@ describe('curateMany orchestration with real workers', () => {
 
     // Real workers were hard-terminated. A fresh run over the same input must
     // still complete — partial output from the aborted run is re-processed.
+    //
+    // KNOWN RACE: mappingWorkerPool holds its state at module level and the
+    // next run resets `aborted` to false. A message still in flight from a
+    // terminated run-1 worker can therefore pass the `if (aborted) return`
+    // guard and mutate run-2 counters. If this assertion ever flakes, that is
+    // the cause — it is a product bug, not a test bug.
     const { result } = await runCapturingProgress(
       integrationOptions(inputDir, outputDir, integrationSpec(), {
         workerCount: 2,

--- a/testutils/integrationHarness.ts
+++ b/testutils/integrationHarness.ts
@@ -1,0 +1,135 @@
+/**
+ * Harness for the `integration` vitest project.
+ *
+ * Integration tests drive real workers loaded from `dist/esm` (the
+ * `dicom-curate` alias in vitest.config.ts), because `curateMany` constructs
+ * its workers from `new URL('./*.js', import.meta.url)` and offers no
+ * injection seam.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, sep } from 'node:path'
+import { curateMany } from 'dicom-curate'
+import { type DicomTagOverrides, generateFile } from 'dicom-synth'
+import type {
+  OrganizeOptions,
+  TCurationSpecification,
+  TProgressMessage,
+} from '../src/types'
+
+export type IntegrationWorkspace = {
+  inputDir: string
+  outputDir: string
+  cleanup: () => void
+}
+
+/** Fail fast when input and output trees could collide. */
+function assertDisjoint(inputDir: string, outputDir: string): void {
+  const input = resolve(inputDir)
+  const output = resolve(outputDir)
+  if (input === output || output.startsWith(input + sep)) {
+    throw new Error(`output dir must not sit inside input dir: ${output}`)
+  }
+}
+
+export function createIntegrationWorkspace(): IntegrationWorkspace {
+  const base = mkdtempSync(join(tmpdir(), 'dicom-curate-integration-'))
+  const inputDir = join(base, 'input')
+  const outputDir = join(base, 'output')
+  mkdirSync(inputDir, { recursive: true })
+  mkdirSync(outputDir, { recursive: true })
+  assertDisjoint(inputDir, outputDir)
+  return {
+    inputDir,
+    outputDir,
+    cleanup: () => rmSync(base, { recursive: true, force: true }),
+  }
+}
+
+/**
+ * Write one valid CT instance to an exact path.
+ *
+ * Generated directly from dicom-synth so this layer does not depend on the
+ * fixture helpers in minimalDicom.ts, which are being reworked in parallel.
+ * Collapse into that module's `writeSynthFile` once the two land together.
+ */
+export async function writeImage(
+  filePath: string,
+  tags?: DicomTagOverrides,
+): Promise<void> {
+  const { buffer } = await generateFile({
+    type: 'valid-image',
+    modality: 'CT',
+    ...(tags ? { tags } : {}),
+  })
+  mkdirSync(join(filePath, '..'), { recursive: true })
+  writeFileSync(filePath, buffer)
+}
+
+/** Minimal spec mirroring an `input/study/subject` tree. */
+export function integrationSpec(): () => TCurationSpecification {
+  return () => ({
+    version: '3.0',
+    hostProps: { protocolNumber: 'integration' },
+    inputPathPattern: 'study/subject',
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: () => ({}),
+    outputFilePathComponents: (parser) => [
+      'curated',
+      parser.getFilePathComp('subject'),
+      parser.getFilePathComp(parser.FILENAME),
+    ],
+    errors: () => [],
+  })
+}
+
+/**
+ * Overridable fields only. Spreading a full `Partial<OrganizeOptions>` would
+ * widen `inputDirectory` back to the union shared with the 'directory' input
+ * variant, breaking the 'path' narrowing below.
+ */
+export type IntegrationOverrides = Partial<
+  Pick<
+    OrganizeOptions,
+    | 'workerCount'
+    | 'skipWrite'
+    | 'hashMethod'
+    | 'dateOffset'
+    | 'signal'
+    | 'skipCollectingMappings'
+  >
+>
+
+export function integrationOptions(
+  inputDir: string,
+  outputDir: string,
+  curationSpec: OrganizeOptions['curationSpec'],
+  overrides?: IntegrationOverrides,
+): OrganizeOptions {
+  assertDisjoint(inputDir, outputDir)
+  return {
+    inputType: 'path',
+    inputDirectory: inputDir,
+    outputDirectory: outputDir,
+    curationSpec,
+    workerCount: 1,
+    ...overrides,
+  }
+}
+
+export type CapturedRun = {
+  result: Awaited<ReturnType<typeof curateMany>>
+  /** Every progress message, in order — the intermediate behaviour under test. */
+  progress: TProgressMessage[]
+}
+
+/** Run `curateMany` against real workers, retaining the progress stream. */
+export async function runCapturingProgress(
+  options: OrganizeOptions,
+): Promise<CapturedRun> {
+  const progress: TProgressMessage[] = []
+  const result = await curateMany(options, (msg: TProgressMessage) => {
+    progress.push(msg)
+  })
+  return { result, progress }
+}

--- a/testutils/integrationHarness.ts
+++ b/testutils/integrationHarness.ts
@@ -66,6 +66,26 @@ export async function writeImage(
   writeFileSync(filePath, buffer)
 }
 
+/**
+ * Write `count` distinct instances into `study/subject/` under `inputDir`.
+ * Each gets a unique PatientID so results can be matched back to their source.
+ * Returns the leaf filenames written.
+ */
+export async function writeImages(
+  inputDir: string,
+  count: number,
+): Promise<string[]> {
+  const names: string[] = []
+  for (let i = 0; i < count; i++) {
+    const name = `instance-${String(i).padStart(4, '0')}.dcm`
+    await writeImage(join(inputDir, 'study', 'subject', name), {
+      PatientID: `PID-${String(i).padStart(4, '0')}`,
+    })
+    names.push(name)
+  }
+  return names
+}
+
 /** Minimal spec mirroring an `input/study/subject` tree. */
 export function integrationSpec(): () => TCurationSpecification {
   return () => ({
@@ -123,13 +143,39 @@ export type CapturedRun = {
   progress: TProgressMessage[]
 }
 
-/** Run `curateMany` against real workers, retaining the progress stream. */
+/**
+ * Run `curateMany` against real workers, retaining the progress stream.
+ * `onMessage` fires for each message, so a test can act once work is genuinely
+ * in flight rather than guessing with a timer.
+ */
 export async function runCapturingProgress(
   options: OrganizeOptions,
+  onMessage?: (msg: TProgressMessage) => void,
 ): Promise<CapturedRun> {
   const progress: TProgressMessage[] = []
   const result = await curateMany(options, (msg: TProgressMessage) => {
     progress.push(msg)
+    onMessage?.(msg)
   })
   return { result, progress }
+}
+
+/**
+ * As above, but resolves with the rejection instead of throwing — so the
+ * progress captured before a failure stays inspectable.
+ */
+export async function runExpectingRejection(
+  options: OrganizeOptions,
+  onMessage?: (msg: TProgressMessage) => void,
+): Promise<{ progress: TProgressMessage[]; error: unknown }> {
+  const progress: TProgressMessage[] = []
+  try {
+    await curateMany(options, (msg: TProgressMessage) => {
+      progress.push(msg)
+      onMessage?.(msg)
+    })
+    return { progress, error: undefined }
+  } catch (error) {
+    return { progress, error }
+  }
 }

--- a/testutils/integrationHarness.ts
+++ b/testutils/integrationHarness.ts
@@ -6,23 +6,16 @@
  * its workers from `new URL('./*.js', import.meta.url)` and offers no
  * injection seam.
  */
-import {
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
 import { curateMany } from 'dicom-curate'
-import { type DicomTagOverrides, generateFile } from 'dicom-synth'
 import type {
   OrganizeOptions,
   TCurationSpecification,
   TProgressMessage,
 } from '../src/types'
+import { VALID_CT_IMAGE, writeSynthFile } from './synthFixtures'
 
 export type IntegrationWorkspace = {
   inputDir: string
@@ -53,44 +46,41 @@ export function createIntegrationWorkspace(): IntegrationWorkspace {
   }
 }
 
-/**
- * Write one valid CT instance to an exact path.
- *
- * Generated directly from dicom-synth so this layer does not depend on the
- * fixture helpers in minimalDicom.ts, which are being reworked in parallel.
- * Collapse into that module's `writeSynthFile` once the two land together.
- */
-export async function writeImage(
-  filePath: string,
-  tags?: DicomTagOverrides,
-): Promise<void> {
-  const { buffer } = await generateFile({
-    type: 'valid-image',
-    modality: 'CT',
-    ...(tags ? { tags } : {}),
-  })
-  mkdirSync(join(filePath, '..'), { recursive: true })
-  writeFileSync(filePath, buffer)
+export type WrittenImage = {
+  /** Leaf filename under `study/subject/`. */
+  name: string
+  /** PatientID written into the instance, for matching results to sources. */
+  patientId: string
 }
 
 /**
- * Write `count` distinct instances into `study/subject/` under `inputDir`.
- * Each gets a unique PatientID so results can be matched back to their source.
- * Returns the leaf filenames written.
+ * Write `count` instances into `study/subject/` under `inputDir`.
+ *
+ * Each gets a unique PatientID so results can be matched back to their source,
+ * and a distinct `index` so the generated SOPInstanceUIDs differ — output
+ * filenames derive from that UID, so identical instances would collapse onto
+ * one path.
+ *
+ * Returns what was written: read the ids from here rather than re-deriving the
+ * naming convention, so callers cannot silently drift from it.
  */
 export async function writeImages(
   inputDir: string,
   count: number,
-): Promise<string[]> {
-  const names: string[] = []
+): Promise<WrittenImage[]> {
+  const written: WrittenImage[] = []
   for (let i = 0; i < count; i++) {
-    const name = `instance-${String(i).padStart(4, '0')}.dcm`
-    await writeImage(join(inputDir, 'study', 'subject', name), {
-      PatientID: `PID-${String(i).padStart(4, '0')}`,
-    })
-    names.push(name)
+    const id = String(i).padStart(4, '0')
+    const name = `instance-${id}.dcm`
+    const patientId = `PID-${id}`
+    await writeSynthFile(
+      join(inputDir, 'study', 'subject', name),
+      { ...VALID_CT_IMAGE, tags: { PatientID: patientId } },
+      { index: i },
+    )
+    written.push({ name, patientId })
   }
-  return names
+  return written
 }
 
 /** Every file under `dir`, recursively, as paths relative to `dir`. */

--- a/testutils/integrationHarness.ts
+++ b/testutils/integrationHarness.ts
@@ -6,7 +6,14 @@
  * its workers from `new URL('./*.js', import.meta.url)` and offers no
  * injection seam.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
 import { curateMany } from 'dicom-curate'
@@ -86,6 +93,21 @@ export async function writeImages(
   return names
 }
 
+/** Every file under `dir`, recursively, as paths relative to `dir`. */
+export function listFilesRecursive(dir: string, prefix = ''): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const rel = prefix ? `${prefix}/${entry}` : entry
+    if (statSync(full).isDirectory()) {
+      out.push(...listFilesRecursive(full, rel))
+    } else {
+      out.push(rel)
+    }
+  }
+  return out
+}
+
 /** Minimal spec mirroring an `input/study/subject` tree. */
 export function integrationSpec(): () => TCurationSpecification {
   return () => ({
@@ -117,8 +139,43 @@ export type IntegrationOverrides = Partial<
     | 'dateOffset'
     | 'signal'
     | 'skipCollectingMappings'
+    | 'table'
   >
 >
+
+/**
+ * Spec for the CSV-load (two-pass) mapping flow: PatientID is rewritten from a
+ * `table` joined on the original value. Pair with `table: [{ oldId, newId }]`
+ * on the options.
+ */
+export function csvMappingSpec(): () => TCurationSpecification {
+  return () => ({
+    version: '3.0',
+    hostProps: {},
+    inputPathPattern: 'study/subject',
+    dicomPS315EOptions: 'Off',
+    modifyDicomHeader: (parser) => ({
+      PatientID: String(parser.getMapping?.('centerSubjectId')),
+    }),
+    additionalData: {
+      type: 'load',
+      collect: {},
+      mapping: {
+        centerSubjectId: {
+          value: (p) => p.getDicom('PatientID'),
+          lookup: (row) => String(row.oldId),
+          replace: (row) => String(row.newId),
+        },
+      },
+    },
+    outputFilePathComponents: (parser) => [
+      'curated',
+      parser.getFilePathComp('subject'),
+      parser.getFilePathComp(parser.FILENAME),
+    ],
+    errors: () => [],
+  })
+}
 
 export function integrationOptions(
   inputDir: string,

--- a/testutils/integrationHarness.ts
+++ b/testutils/integrationHarness.ts
@@ -6,43 +6,52 @@
  * its workers from `new URL('./*.js', import.meta.url)` and offers no
  * injection seam.
  */
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join, resolve, sep } from 'node:path'
+import { join } from 'node:path'
 import { curateMany } from 'dicom-curate'
+import { afterEach } from 'vitest'
 import type {
   OrganizeOptions,
   TCurationSpecification,
   TProgressMessage,
 } from '../src/types'
 import { VALID_CT_IMAGE, writeSynthFile } from './synthFixtures'
+import {
+  assertInputOutputDisjoint,
+  createWorkspace,
+  INPUT_DIR_NAME,
+  type Workspace,
+} from './workspace'
 
-export type IntegrationWorkspace = {
-  inputDir: string
-  outputDir: string
-  cleanup: () => void
+export { listFilesRecursive, type Workspace } from './workspace'
+
+export function createIntegrationWorkspace(): Workspace {
+  return createWorkspace('dicom-curate-integration-')
 }
 
-/** Fail fast when input and output trees could collide. */
-function assertDisjoint(inputDir: string, outputDir: string): void {
-  const input = resolve(inputDir)
-  const output = resolve(outputDir)
-  if (input === output || output.startsWith(input + sep)) {
-    throw new Error(`output dir must not sit inside input dir: ${output}`)
-  }
+// The specs below hard-code `input/...` because spec functions are serialized
+// to the worker and cannot close over variables. Fail loudly if the workspace
+// layout ever stops matching that literal.
+if (INPUT_DIR_NAME !== 'input') {
+  throw new Error(
+    `integrationHarness specs hard-code 'input/...' but INPUT_DIR_NAME is '${INPUT_DIR_NAME}'`,
+  )
 }
 
-export function createIntegrationWorkspace(): IntegrationWorkspace {
-  const base = mkdtempSync(join(tmpdir(), 'dicom-curate-integration-'))
-  const inputDir = join(base, 'input')
-  const outputDir = join(base, 'output')
-  mkdirSync(inputDir, { recursive: true })
-  mkdirSync(outputDir, { recursive: true })
-  assertDisjoint(inputDir, outputDir)
-  return {
-    inputDir,
-    outputDir,
-    cleanup: () => rmSync(base, { recursive: true, force: true }),
+/**
+ * Register per-test workspace cleanup and return a factory for them. Call once
+ * inside a `describe`; every workspace it hands out is removed after each test.
+ */
+export function useWorkspaces(): () => Workspace {
+  const workspaces: Workspace[] = []
+  afterEach(() => {
+    for (const w of workspaces.splice(0)) {
+      w.cleanup()
+    }
+  })
+  return () => {
+    const w = createIntegrationWorkspace()
+    workspaces.push(w)
+    return w
   }
 }
 
@@ -83,27 +92,24 @@ export async function writeImages(
   return written
 }
 
-/** Every file under `dir`, recursively, as paths relative to `dir`. */
-export function listFilesRecursive(dir: string, prefix = ''): string[] {
-  const out: string[] = []
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    const rel = prefix ? `${prefix}/${entry}` : entry
-    if (statSync(full).isDirectory()) {
-      out.push(...listFilesRecursive(full, rel))
-    } else {
-      out.push(rel)
-    }
-  }
-  return out
-}
-
-/** Minimal spec mirroring an `input/study/subject` tree. */
+/**
+ * Minimal spec mirroring the `input/study/subject` tree `createWorkspace`
+ * builds.
+ *
+ * The pattern's leading `input` is required, not incidental: scanned paths are
+ * relative to the scan root's parent, so they start with the input directory's
+ * own basename. Omitting it shifts every `getFilePathComp` lookup by one and
+ * silently returns the wrong segment rather than erroring.
+ *
+ * It must stay an inline literal — spec functions are serialized to the worker
+ * and `checkClosure` rejects any closed-over variable, so this cannot reference
+ * `INPUT_DIR_NAME`. The assertion below keeps the two in step.
+ */
 export function integrationSpec(): () => TCurationSpecification {
   return () => ({
     version: '3.0',
     hostProps: { protocolNumber: 'integration' },
-    inputPathPattern: 'study/subject',
+    inputPathPattern: 'input/study/subject',
     dicomPS315EOptions: 'Off',
     modifyDicomHeader: () => ({}),
     outputFilePathComponents: (parser) => [
@@ -134,19 +140,31 @@ export type IntegrationOverrides = Partial<
 >
 
 /**
- * Spec for the CSV-load (two-pass) mapping flow: PatientID is rewritten from a
- * `table` joined on the original value. Pair with `table: [{ oldId, newId }]`
- * on the options.
+ * Spec for the direct CSV-load mapping flow (`additionalData.type: 'load'`):
+ * PatientID is rewritten from a supplied `table`, joined on the original
+ * value. Requires `table: [{ oldId, newId }]` on the options.
+ *
+ * Not the two-pass flow — that is `type: 'listing'`, which derives its mapping
+ * from a first read-only pass instead of a caller-supplied table.
  */
 export function csvMappingSpec(): () => TCurationSpecification {
   return () => ({
     version: '3.0',
     hostProps: {},
-    inputPathPattern: 'study/subject',
+    // Inline literal, and must include the input dir basename — see
+    // integrationSpec above.
+    inputPathPattern: 'input/study/subject',
     dicomPS315EOptions: 'Off',
-    modifyDicomHeader: (parser) => ({
-      PatientID: String(parser.getMapping?.('centerSubjectId')),
-    }),
+    modifyDicomHeader: (parser) => {
+      // Without a `table`, getMapping is undefined and `String(undefined)`
+      // would write the literal 'undefined' as PatientID with no error at all.
+      if (!parser.getMapping) {
+        throw new Error(
+          'csvMappingSpec requires `table` in the curate options (no mapping resolver was supplied)',
+        )
+      }
+      return { PatientID: String(parser.getMapping('centerSubjectId')) }
+    },
     additionalData: {
       type: 'load',
       collect: {},
@@ -173,7 +191,7 @@ export function integrationOptions(
   curationSpec: OrganizeOptions['curationSpec'],
   overrides?: IntegrationOverrides,
 ): OrganizeOptions {
-  assertDisjoint(inputDir, outputDir)
+  assertInputOutputDisjoint(inputDir, outputDir)
   return {
     inputType: 'path',
     inputDirectory: inputDir,
@@ -210,6 +228,10 @@ export async function runCapturingProgress(
 /**
  * As above, but resolves with the rejection instead of throwing — so the
  * progress captured before a failure stays inspectable.
+ *
+ * Throws if the run *completes*: a caller using this expects a rejection, and
+ * surfacing that as `error: undefined` would turn a real regression into a
+ * confusing assertion mismatch further down the test.
  */
 export async function runExpectingRejection(
   options: OrganizeOptions,
@@ -221,8 +243,10 @@ export async function runExpectingRejection(
       progress.push(msg)
       onMessage?.(msg)
     })
-    return { progress, error: undefined }
   } catch (error) {
     return { progress, error }
   }
+  throw new Error(
+    `expected curateMany to reject, but it completed after ${progress.length} progress messages`,
+  )
 }

--- a/testutils/synthFixtures.ts
+++ b/testutils/synthFixtures.ts
@@ -39,12 +39,20 @@ const FIXTURE_SEED = 1
  * Exists because dicom-synth has no equivalent: `generateFile` performs no
  * I/O, and `writeCollectionFromSpec` derives its own filenames and layout, so
  * neither can target the caller-chosen paths these tests assert on.
+ *
+ * `index` varies the generated UIDs while keeping the seed pinned, so a test
+ * writing several files gets distinct instances that are still reproducible.
+ * Omit it whenever one file is enough.
  */
 export async function writeSynthFile(
   filePath: string,
   spec: FileSpec,
+  options?: { index?: number },
 ): Promise<void> {
-  const { buffer } = await generateFile(spec, { seed: FIXTURE_SEED })
+  const { buffer } = await generateFile(spec, {
+    seed: FIXTURE_SEED,
+    index: options?.index,
+  })
   mkdirSync(join(filePath, '..'), { recursive: true })
   writeFileSync(filePath, buffer)
 }

--- a/testutils/workspace.ts
+++ b/testutils/workspace.ts
@@ -1,0 +1,107 @@
+/**
+ * Temp input/output workspaces and directory helpers, shared by the e2e and
+ * integration suites.
+ *
+ * Both layers need the same disjointness guard and recursive listing; keeping
+ * one copy here stops the two drifting apart.
+ */
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative, resolve, sep } from 'node:path'
+
+export type Workspace = {
+  inputDir: string
+  outputDir: string
+  cleanup: () => void
+}
+
+/** Fail fast when input and output trees could collide, in either direction. */
+export function assertInputOutputDisjoint(
+  inputDir: string,
+  outputDir: string,
+): void {
+  const input = resolve(inputDir)
+  const output = resolve(outputDir)
+  if (
+    input === output ||
+    input.startsWith(output + sep) ||
+    output.startsWith(input + sep)
+  ) {
+    throw new Error(
+      `Input and output directories must not overlap (input=${input}, output=${output})`,
+    )
+  }
+}
+
+/**
+ * The basename of the input directory created below. Scanned paths are
+ * relative to the scan root's *parent*, so they start with this segment — any
+ * `inputPathPattern` matching against them must account for it.
+ */
+export const INPUT_DIR_NAME = 'input'
+
+export function createWorkspace(prefix: string): Workspace {
+  const base = mkdtempSync(join(tmpdir(), prefix))
+  const inputDir = join(base, INPUT_DIR_NAME)
+  const outputDir = join(base, 'output')
+  mkdirSync(inputDir, { recursive: true })
+  mkdirSync(outputDir, { recursive: true })
+  assertInputOutputDisjoint(inputDir, outputDir)
+  return {
+    inputDir,
+    outputDir,
+    cleanup: () => {
+      if (existsSync(base)) {
+        rmSync(base, { recursive: true, force: true })
+      }
+    },
+  }
+}
+
+/** Every file under `root`, recursively, sorted, relative to `root`. */
+export function listFilesRecursive(root: string): string[] {
+  const files: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+      } else {
+        files.push(relative(root, full))
+      }
+    }
+  }
+  if (existsSync(root)) {
+    walk(root)
+  }
+  return files.sort()
+}
+
+export function hashDirectoryFiles(root: string): Map<string, string> {
+  const hashes = new Map<string, string>()
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+      } else {
+        hashes.set(
+          relative(root, full),
+          createHash('sha256').update(readFileSync(full)).digest('hex'),
+        )
+      }
+    }
+  }
+  if (existsSync(root)) {
+    walk(root)
+  }
+  return hashes
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
             '**/dist/**',
             'e2e/**',
             'conformance/**',
+            // Runs in the 'integration' project instead: needs the dist/esm
+            // build, so it cannot run in the fast unit pass.
+            'src/**/*.integration.test.ts',
           ],
           server: {
             deps: {
@@ -60,6 +63,22 @@ export default defineConfig({
         test: {
           name: 'e2e',
           include: ['e2e/**/*.test.ts'],
+          exclude: ['**/node_modules/**', '**/dist/**'],
+          testTimeout: 120_000,
+          hookTimeout: 30_000,
+          server: {
+            deps: {
+              inline: ['@noble/hashes'],
+            },
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          // Cross-module flows driven through real workers from dist/esm.
+          name: 'integration',
+          include: ['src/**/*.integration.test.ts'],
           exclude: ['**/node_modules/**', '**/dist/**'],
           testTimeout: 120_000,
           hookTimeout: 30_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,19 @@ import { defineConfig } from 'vitest/config'
 
 const repoRoot = fileURLToPath(new URL('.', import.meta.url))
 
+const COMMON_EXCLUDE = ['**/node_modules/**', '**/dist/**']
+
+/** Inlined so vitest transforms its ESM rather than failing to require it. */
+const inlineDeps = (...extra: string[]) => ({
+  deps: { inline: ['@noble/hashes', ...extra] },
+})
+
+/** Suites that build and drive the real dist/esm workers need longer limits. */
+const REAL_WORKER_TIMEOUTS = {
+  testTimeout: 120_000,
+  hookTimeout: 30_000,
+}
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -43,19 +56,14 @@ export default defineConfig({
           name: 'unit',
           include: ['src/**/*.test.ts'],
           exclude: [
-            '**/node_modules/**',
-            '**/dist/**',
+            ...COMMON_EXCLUDE,
             'e2e/**',
             'conformance/**',
             // Runs in the 'integration' project instead: needs the dist/esm
             // build, so it cannot run in the fast unit pass.
             'src/**/*.integration.test.ts',
           ],
-          server: {
-            deps: {
-              inline: ['@noble/hashes'],
-            },
-          },
+          server: inlineDeps(),
         },
       },
       {
@@ -63,14 +71,9 @@ export default defineConfig({
         test: {
           name: 'e2e',
           include: ['e2e/**/*.test.ts'],
-          exclude: ['**/node_modules/**', '**/dist/**'],
-          testTimeout: 120_000,
-          hookTimeout: 30_000,
-          server: {
-            deps: {
-              inline: ['@noble/hashes'],
-            },
-          },
+          exclude: COMMON_EXCLUDE,
+          ...REAL_WORKER_TIMEOUTS,
+          server: inlineDeps(),
         },
       },
       {
@@ -79,14 +82,9 @@ export default defineConfig({
           // Cross-module flows driven through real workers from dist/esm.
           name: 'integration',
           include: ['src/**/*.integration.test.ts'],
-          exclude: ['**/node_modules/**', '**/dist/**'],
-          testTimeout: 120_000,
-          hookTimeout: 30_000,
-          server: {
-            deps: {
-              inline: ['@noble/hashes'],
-            },
-          },
+          exclude: COMMON_EXCLUDE,
+          ...REAL_WORKER_TIMEOUTS,
+          server: inlineDeps(),
         },
       },
       {
@@ -94,13 +92,9 @@ export default defineConfig({
         test: {
           name: 'conformance',
           include: ['conformance/**/*.test.ts'],
-          exclude: ['**/node_modules/**', '**/dist/**'],
+          exclude: COMMON_EXCLUDE,
           testTimeout: 120_000,
-          server: {
-            deps: {
-              inline: ['@noble/hashes', 'dcmjs', 'dicom-synth'],
-            },
-          },
+          server: inlineDeps('dcmjs', 'dicom-synth'),
         },
       },
     ],


### PR DESCRIPTION
**Test-only changes**

Adds a new vitest project for true integration tests, and runs them in CI.

These focus on intermediate workings (e.g. progress messages, per-file results, failure handling), rather than outputs, which will be the responsibility of e2e. Similarly, some tests previously regarded as 'integration' have been recategorised as unit tests. These new tests exercise the real worker pool from esm build files.

New suites

- curateMany.integration.test.ts — incremental progress reporting; output path construction through getFilePathComp against a real scan.
- orchestration.integration.test.ts — every file processed exactly once across a 4-worker pool; scan backpressure; abort mid-run then a clean rerun over the same input.
- csvMapping.integration.test.ts — direct CSV-load mapping (additionalData.type: 'load'): each CSV row binds to its own file across a concurrent batch, catching mis-attribution that the single-file unit test can't.

Supporting changes

- testutils/integrationHarness.ts — shared spec/options/run helpers, including useWorkspaces() (self-cleaning temp workspaces) and runExpectingRejection (fails loudly if the run completes).
- testutils/workspace.ts — workspace/disjointness/listing helpers, now shared with e2e.
- CI runs pnpm test:integration; the unit project excludes *.integration.test.ts; test:watch is scoped to unit so it doesn't run integration suites against a stale dist/esm. README updated to match.

Notes

- The abort test documents a known product race in mappingWorkerPool (module-level state; raised separately) — if it ever flakes, that's the cause. #302 