### PR TITLE
Fix/280 pump hang hardening

### DIFF
--- a/src/applyMappingsCore.ts
+++ b/src/applyMappingsCore.ts
@@ -51,6 +51,9 @@ type MapResults = Awaited<ReturnType<typeof curateOne>>
 /** Everything the mapping worker sends back to the main thread. */
 export type MappingResponse =
   | { response: 'error'; error: string; fileInfo: TFileInfo }
+  // Sent by applyMappingsWorker.ts, not this handler: the environment never
+  // initialized, so the pool must stop dispatching to this worker.
+  | { response: 'initError'; error: string }
   | { response: 'lookup'; outputPath: string }
   | {
       response: 'upload'

--- a/src/applyMappingsWorker.ts
+++ b/src/applyMappingsWorker.ts
@@ -44,6 +44,24 @@ fixupNodeWorkerEnvironment()
   })
   .catch((error) => {
     // If fixupNodeWorkerEnvironment() fails, the worker can never process
-    // messages. Log the error so it's visible in the console.
-    console.error('Failed to initialize mapping worker environment:', error)
+    // messages: dispatched files vanish silently until the stall watchdog
+    // notices up to 10 minutes later. Log here (worker-thread console, the
+    // only place the detailed reason is visible) and tell the pool: a
+    // response tag outside the normal union routes through its default:
+    // branch, which terminates and replaces the worker and accounts any
+    // in-flight file. Only effective if a file was already dispatched:
+    // recoverCrashedWorker bails for an idle worker (a pre-existing gap),
+    // leaving the watchdog as the only cover.
+    const message = `Failed to initialize mapping worker environment: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+    console.error(message, error)
+    try {
+      emit({
+        response: 'initError',
+        error: message,
+      } as unknown as MappingResponse)
+    } catch {
+      // postMessage unavailable -- already logged above.
+    }
   })

--- a/src/applyMappingsWorker.ts
+++ b/src/applyMappingsWorker.ts
@@ -43,25 +43,24 @@ fixupNodeWorkerEnvironment()
     globalThis.addEventListener('message', handleMessage)
   })
   .catch((error) => {
-    // If fixupNodeWorkerEnvironment() fails, the worker can never process
-    // messages: dispatched files vanish silently until the stall watchdog
-    // notices up to 10 minutes later. Log here (worker-thread console, the
-    // only place the detailed reason is visible) and tell the pool: a
-    // response tag outside the normal union routes through its default:
-    // branch, which terminates and replaces the worker and accounts any
-    // in-flight file. Only effective if a file was already dispatched:
-    // recoverCrashedWorker bails for an idle worker (a pre-existing gap),
-    // leaving the watchdog as the only cover.
+    // Without an environment the worker can never process messages, so
+    // dispatched files would vanish until the watchdog notices 10 minutes
+    // later. 'initError' tells the pool to drop it and account any file
+    // already in flight; the log carries the reason, visible only here.
     const message = `Failed to initialize mapping worker environment: ${
       error instanceof Error ? error.message : String(error)
     }`
     console.error(message, error)
+    const msg: MappingResponse = { response: 'initError', error: message }
     try {
-      emit({
-        response: 'initError',
-        error: message,
-      } as unknown as MappingResponse)
+      emit(msg)
     } catch {
-      // postMessage unavailable -- already logged above.
+      // Under Node the rejection happens before fixupNodeWorkerEnvironment()
+      // installs globalThis.postMessage, so emit() itself throws. Go direct,
+      // matching the { data } wrapping the fixup applies (see worker.ts). If
+      // worker_threads was itself the failure, the log above is the last word.
+      void import('worker_threads')
+        .then(({ parentPort }) => parentPort?.postMessage({ data: msg }))
+        .catch(() => {})
     }
   })

--- a/src/curateMany.integration.test.ts
+++ b/src/curateMany.integration.test.ts
@@ -6,6 +6,7 @@
  * reach the caller through the progress stream as work proceeds rather than
  * only in the final result.
  */
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   integrationOptions,
@@ -50,6 +51,48 @@ describe('curateMany driven through real workers', () => {
       .map((m) => m.processedFiles)
       .filter((n): n is number => typeof n === 'number')
     expect(counts).toEqual([...counts].sort((a, b) => a - b))
+  })
+
+  it('completes for in-memory file input, which never runs a scan', async () => {
+    const { inputDir, outputDir } = workspace()
+    const inputPath = join(inputDir, 'study', 'subject', 'only.dcm')
+    await writeSynthFile(inputPath, VALID_CT_IMAGE)
+
+    // No scan worker exists on this path, so nothing but queueFilesForMapping
+    // can mark the scan finished -- and without that the run never settles.
+    const { result } = await runCapturingProgress({
+      ...integrationOptions(inputDir, outputDir, integrationSpec()),
+      inputType: 'files',
+      inputFiles: [
+        new File([Uint8Array.from(await readFile(inputPath))], 'only.dcm'),
+      ],
+    } as never)
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(1)
+  })
+
+  it('settles on an empty queue for both directly-queued input types', async () => {
+    const { inputDir, outputDir } = workspace()
+    const base = integrationOptions(inputDir, outputDir, integrationSpec())
+
+    // Neither input type runs a scan, so an empty list is the shortest path to
+    // the termination condition -- and the one that never reaches a worker.
+    const files = await runCapturingProgress({
+      ...base,
+      inputType: 'files',
+      inputFiles: [],
+    } as never)
+    expect(files.result.response).toBe('done')
+    expect(files.result.processedFiles).toBe(0)
+
+    const urls = await runCapturingProgress({
+      ...base,
+      inputType: 'http',
+      inputUrls: [],
+    } as never)
+    expect(urls.result.response).toBe('done')
+    expect(urls.result.processedFiles).toBe(0)
   })
 
   it('surfaces per-file mapping results through the progress stream', async () => {

--- a/src/curateMany.test.ts
+++ b/src/curateMany.test.ts
@@ -36,9 +36,9 @@ describe('curateMany', () => {
       availableMappingWorkers: [],
       dispatchMappingJobs: vi.fn(),
       filesToProcess: [],
-      getLastWorkerProgressTime: vi.fn(() => Date.now()),
+      getLastMappingProgressTime: vi.fn(() => Date.now()),
+      getLastScanProgressTime: vi.fn(() => Date.now()),
       getPendingReplacements: vi.fn(() => 0),
-      getQueueLength: vi.fn(() => 0),
       getWorkerCurrentFile: vi.fn(() => new Map()),
       getWorkersActive: vi.fn(() => 0),
       initializeMappingWorkers: vi.fn(
@@ -52,7 +52,8 @@ describe('curateMany', () => {
       ),
       isDirectoryScanFinished: vi.fn(() => true),
       markScanPaused: vi.fn(),
-      resetWorkerProgressTime: vi.fn(),
+      resetProgressTimestamps: vi.fn(),
+      resetScanProgressTime: vi.fn(),
       scanAnomalies: [],
       setDirectoryScanFinished: vi.fn(),
       setAbortSignal: vi.fn(),
@@ -367,9 +368,9 @@ describe('curateMany', () => {
         string,
         MockedFunction<() => number | boolean>
       >
-      pool.getLastWorkerProgressTime.mockReturnValue(0)
+      pool.getLastMappingProgressTime.mockReturnValue(0)
+      pool.getLastScanProgressTime.mockReturnValue(0)
       pool.getWorkersActive.mockReturnValue(0)
-      pool.getQueueLength.mockReturnValue(0)
       pool.isDirectoryScanFinished.mockReturnValue(true)
       pool.getPendingReplacements.mockReturnValue(1)
 
@@ -382,6 +383,9 @@ describe('curateMany', () => {
       } as any)
 
       await flushAsyncSetup()
+      // Drain the URL queued at setup: the watchdog reads the live queue, and
+      // this scenario needs it empty.
+      mappingWorkerPool.filesToProcess.length = 0
       const dispatchesBeforeTick = (
         mappingWorkerPool.dispatchMappingJobs as MockedFunction<
           typeof mappingWorkerPool.dispatchMappingJobs
@@ -409,9 +413,9 @@ describe('curateMany', () => {
         string,
         MockedFunction<() => number | boolean>
       >
-      pool.getLastWorkerProgressTime.mockReturnValue(0)
+      pool.getLastMappingProgressTime.mockReturnValue(0)
+      pool.getLastScanProgressTime.mockReturnValue(0)
       pool.getWorkersActive.mockReturnValue(0)
-      pool.getQueueLength.mockReturnValue(0)
       pool.isDirectoryScanFinished.mockReturnValue(true)
       pool.getPendingReplacements.mockReturnValue(0)
 
@@ -424,6 +428,9 @@ describe('curateMany', () => {
       } as any)
 
       await flushAsyncSetup()
+      // Drain the URL queued at setup: the watchdog reads the live queue, and
+      // a genuinely finished run has it empty.
+      mappingWorkerPool.filesToProcess.length = 0
       const dispatchesBeforeTick = (
         mappingWorkerPool.dispatchMappingJobs as MockedFunction<
           typeof mappingWorkerPool.dispatchMappingJobs

--- a/src/curateMany.test.ts
+++ b/src/curateMany.test.ts
@@ -5,10 +5,37 @@ async function flushAsyncSetup() {
   await Promise.resolve()
   await Promise.resolve()
 }
+
+/** Longer form, for setups that await a worker creation part way through. */
+async function flushTicks(rounds = 30) {
+  for (let tick = 0; tick < rounds; tick++) {
+    await Promise.resolve()
+  }
+}
+
+/**
+ * Scan worker stand-in: only the surface initializeFileListWorker touches.
+ * Deliberately has no `on`, so the Node-only 'exit' wiring is skipped.
+ */
+function makeMockScanWorker() {
+  const messageListeners: ((event: { data: unknown }) => void)[] = []
+  return {
+    onerror: null as ((event: unknown) => void) | null,
+    terminate: vi.fn(),
+    postMessage: vi.fn(),
+    addEventListener: vi.fn((event: string, listener: any) => {
+      if (event === 'message') messageListeners.push(listener)
+    }),
+    emitMessage(data: unknown) {
+      for (const listener of messageListeners) listener({ data })
+    },
+  }
+}
 describe('curateMany', () => {
   let curateMany: typeof import('./index').curateMany
   let mappingWorkerPool: typeof import('./mappingWorkerPool')
   let composeSpecsModule: typeof import('./composeSpecs')
+  let workerModule: typeof import('./worker')
 
   let capturedProgressCallback: ((msg: any) => void) | undefined
 
@@ -76,6 +103,7 @@ describe('curateMany', () => {
 
     mappingWorkerPool = await import('./mappingWorkerPool')
     composeSpecsModule = await import('./composeSpecs')
+    workerModule = await import('./worker')
     ;({ curateMany } = await import('./index'))
   })
 
@@ -473,5 +501,177 @@ describe('curateMany', () => {
       ([msg]) => msg.response === 'done',
     )
     expect(doneCalls).toHaveLength(1)
+  })
+
+  it('terminates the mapping pool when setup throws after the pool is built', async () => {
+    ;(
+      composeSpecsModule.composeSpecs as MockedFunction<
+        typeof composeSpecsModule.composeSpecs
+      >
+    ).mockReturnValueOnce({
+      dicomPS315EOptions: {
+        retainLongitudinalTemporalInformationOptions: 'Offset',
+      },
+    } as any)
+
+    await expect(
+      curateMany({
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: () => ({}),
+        dateOffset: 'not-an-iso8601-offset',
+      } as any),
+    ).rejects.toThrow(
+      'When using "Offset" for retainLongitudinalTemporalInformationOptions',
+    )
+
+    expect(mappingWorkerPool.terminateAllWorkers).toHaveBeenCalledTimes(1)
+  })
+
+  // Both teardown paths terminate fileListWorker, and both see it as undefined
+  // until the assignment completes, so a run that settles during creation has
+  // nothing left able to stop the scan worker.
+  it('terminates a scan worker created for a run that settled during its creation', async () => {
+    const scanWorker = makeMockScanWorker()
+    let resolveCreate: ((worker: unknown) => void) | undefined
+    ;(
+      workerModule.createWorker as MockedFunction<
+        typeof workerModule.createWorker
+      >
+    ).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve as (worker: unknown) => void
+        }),
+    )
+
+    const controller = new AbortController()
+    const promise = curateMany({
+      inputType: 'path',
+      inputDirectory: '/tmp/curate-many-test',
+      curationSpec: 'none',
+      signal: controller.signal,
+    } as any)
+
+    await flushTicks()
+    expect(resolveCreate).toBeDefined()
+
+    controller.abort()
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+
+    // The worker only exists now: after the run settled, and after both
+    // teardown paths ran and found nothing to terminate.
+    resolveCreate!(scanWorker)
+    await flushTicks()
+
+    expect(scanWorker.terminate).toHaveBeenCalledTimes(1)
+    // A scan request from here walks the whole input tree for a dead run and
+    // holds the Node event loop open with nothing able to stop it.
+    expect(scanWorker.postMessage).not.toHaveBeenCalled()
+  })
+
+  // A late event from a finished run's scanner reaches whatever is in the
+  // module-global pool by then -- possibly a later run's idle workers.
+  it("leaves the mapping pool alone when a settled run's scanner reports late", async () => {
+    const scanWorker = makeMockScanWorker()
+    ;(
+      workerModule.createWorker as MockedFunction<
+        typeof workerModule.createWorker
+      >
+    ).mockResolvedValueOnce(scanWorker as unknown as Worker)
+
+    const promise = curateMany({
+      inputType: 'path',
+      inputDirectory: '/tmp/curate-many-test',
+      curationSpec: 'none',
+    } as any)
+
+    await flushTicks()
+    emitDone()
+    await expect(promise).resolves.toBeDefined()
+
+    // Stands in for the idle pool of whichever run is current by then.
+    const laterRunWorker = { terminate: vi.fn() }
+    mappingWorkerPool.availableMappingWorkers.push(
+      laterRunWorker as unknown as Worker,
+    )
+
+    scanWorker.onerror!({ message: 'Scan worker crashed' })
+    scanWorker.emitMessage({ response: 'error', error: 'Scan worker error' })
+
+    expect(laterRunWorker.terminate).not.toHaveBeenCalled()
+    // failRun is settled-guarded.
+    expect(mappingWorkerPool.terminateAllWorkers).not.toHaveBeenCalled()
+  })
+
+  // The watchdog's no-mapping-work branch also holds during start-up and
+  // permanently for an inputType that starts no scanner. Settling such a run is
+  // right, but naming a component that never ran misdirects the operator.
+  it('does not blame the scan worker when no scan was ever started', async () => {
+    vi.useFakeTimers()
+    try {
+      const pool = mappingWorkerPool as unknown as Record<
+        string,
+        MockedFunction<() => number | boolean>
+      >
+      pool.getLastMappingProgressTime.mockReturnValue(0)
+      pool.getLastScanProgressTime.mockReturnValue(0)
+      pool.getWorkersActive.mockReturnValue(0)
+      pool.isDirectoryScanFinished.mockReturnValue(false)
+      pool.getPendingReplacements.mockReturnValue(0)
+
+      const promise = curateMany({
+        inputType: 'not-a-supported-input-type',
+        curationSpec: 'none',
+      } as any)
+
+      await flushTicks()
+      vi.advanceTimersByTime(60_000)
+
+      await expect(promise).rejects.toThrow(
+        'No mapping work and no directory scan in progress for 10 minutes',
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still blames the scan worker once a scan has actually been requested', async () => {
+    const scanWorker = makeMockScanWorker()
+    ;(
+      workerModule.createWorker as MockedFunction<
+        typeof workerModule.createWorker
+      >
+    ).mockResolvedValueOnce(scanWorker as unknown as Worker)
+
+    vi.useFakeTimers()
+    try {
+      const pool = mappingWorkerPool as unknown as Record<
+        string,
+        MockedFunction<() => number | boolean>
+      >
+      pool.getLastMappingProgressTime.mockReturnValue(0)
+      pool.getLastScanProgressTime.mockReturnValue(0)
+      pool.getWorkersActive.mockReturnValue(0)
+      pool.isDirectoryScanFinished.mockReturnValue(false)
+      pool.getPendingReplacements.mockReturnValue(0)
+
+      const promise = curateMany({
+        inputType: 'path',
+        inputDirectory: '/tmp/curate-many-test',
+        curationSpec: 'none',
+      } as any)
+
+      await flushTicks()
+      expect(scanWorker.postMessage).toHaveBeenCalled()
+
+      vi.advanceTimersByTime(60_000)
+
+      await expect(promise).rejects.toThrow(
+        'Scan worker stopped reporting progress for 10 minutes',
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/curateMany.test.ts
+++ b/src/curateMany.test.ts
@@ -37,6 +37,8 @@ describe('curateMany', () => {
       dispatchMappingJobs: vi.fn(),
       filesToProcess: [],
       getLastWorkerProgressTime: vi.fn(() => Date.now()),
+      getPendingReplacements: vi.fn(() => 0),
+      getQueueLength: vi.fn(() => 0),
       getWorkerCurrentFile: vi.fn(() => new Map()),
       getWorkersActive: vi.fn(() => 0),
       initializeMappingWorkers: vi.fn(
@@ -48,7 +50,9 @@ describe('curateMany', () => {
           capturedProgressCallback = progressCallback
         },
       ),
+      isDirectoryScanFinished: vi.fn(() => true),
       markScanPaused: vi.fn(),
+      resetWorkerProgressTime: vi.fn(),
       scanAnomalies: [],
       setDirectoryScanFinished: vi.fn(),
       setAbortSignal: vi.fn(),
@@ -263,6 +267,27 @@ describe('curateMany', () => {
     expect(mappingWorkerPool.filesToProcess).toHaveLength(2)
   })
 
+  it('resolves on the happy path for files input', async () => {
+    const promise = curateMany({
+      inputType: 'files',
+      inputFiles: [new File(['a'], 'file1.dcm'), new File(['b'], 'file2.dcm')],
+      curationSpec: 'none',
+    } as any)
+
+    await flushAsyncSetup()
+
+    emitDone({ fileCount: 2 })
+
+    await expect(promise).resolves.toMatchObject({ response: 'done' })
+
+    expect(mappingWorkerPool.filesToProcess).toHaveLength(2)
+    // Nothing scans for this input type, so this is the only thing that can
+    // make the termination condition reachable.
+    expect(mappingWorkerPool.setDirectoryScanFinished).toHaveBeenCalledWith(
+      true,
+    )
+  })
+
   it('forwards progress messages to the caller before resolving', async () => {
     const onProgress = vi.fn()
 
@@ -304,5 +329,142 @@ describe('curateMany', () => {
     expect(onProgress).toHaveBeenCalledWith(
       expect.objectContaining({ response: 'done' }),
     )
+  })
+
+  it('resolves when the caller throws from the done callback', async () => {
+    const onProgress = vi.fn(() => {
+      throw new Error('consumer callback exploded')
+    })
+
+    const promise = curateMany(
+      {
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: 'none',
+      } as any,
+      onProgress,
+    )
+
+    await flushAsyncSetup()
+
+    // The pool calls this synchronously from its termination block, so a throw
+    // that escapes here would take the pump down with it.
+    expect(() => emitDone({ fileCount: 1 })).not.toThrow()
+
+    await expect(promise).resolves.toMatchObject({
+      response: 'done',
+      fileCount: 1,
+    })
+    expect(onProgress).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the stall watchdog armed while a replacement worker is pending', async () => {
+    vi.useFakeTimers()
+    try {
+      // Idle in every respect the watchdog checks except the one that matters:
+      // a replacement is still being created, so the run is not finished.
+      const pool = mappingWorkerPool as unknown as Record<
+        string,
+        MockedFunction<() => number | boolean>
+      >
+      pool.getLastWorkerProgressTime.mockReturnValue(0)
+      pool.getWorkersActive.mockReturnValue(0)
+      pool.getQueueLength.mockReturnValue(0)
+      pool.isDirectoryScanFinished.mockReturnValue(true)
+      pool.getPendingReplacements.mockReturnValue(1)
+
+      const controller = new AbortController()
+      const promise = curateMany({
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: 'none',
+        signal: controller.signal,
+      } as any)
+
+      await flushAsyncSetup()
+      const dispatchesBeforeTick = (
+        mappingWorkerPool.dispatchMappingJobs as MockedFunction<
+          typeof mappingWorkerPool.dispatchMappingJobs
+        >
+      ).mock.calls.length
+
+      vi.advanceTimersByTime(60_000)
+
+      // Re-pumped rather than written off as a completed run.
+      expect(mappingWorkerPool.dispatchMappingJobs).toHaveBeenCalledTimes(
+        dispatchesBeforeTick + 1,
+      )
+
+      controller.abort()
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('treats a genuinely finished run as no stall', async () => {
+    vi.useFakeTimers()
+    try {
+      const pool = mappingWorkerPool as unknown as Record<
+        string,
+        MockedFunction<() => number | boolean>
+      >
+      pool.getLastWorkerProgressTime.mockReturnValue(0)
+      pool.getWorkersActive.mockReturnValue(0)
+      pool.getQueueLength.mockReturnValue(0)
+      pool.isDirectoryScanFinished.mockReturnValue(true)
+      pool.getPendingReplacements.mockReturnValue(0)
+
+      const controller = new AbortController()
+      const promise = curateMany({
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: 'none',
+        signal: controller.signal,
+      } as any)
+
+      await flushAsyncSetup()
+      const dispatchesBeforeTick = (
+        mappingWorkerPool.dispatchMappingJobs as MockedFunction<
+          typeof mappingWorkerPool.dispatchMappingJobs
+        >
+      ).mock.calls.length
+
+      vi.advanceTimersByTime(60_000)
+
+      expect(mappingWorkerPool.dispatchMappingJobs).toHaveBeenCalledTimes(
+        dispatchesBeforeTick,
+      )
+
+      controller.abort()
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('forwards done to the caller at most once', async () => {
+    const onProgress = vi.fn()
+
+    const promise = curateMany(
+      {
+        inputType: 'http',
+        inputUrls: ['https://example.com/file.dcm'],
+        curationSpec: 'none',
+      } as any,
+      onProgress,
+    )
+
+    await flushAsyncSetup()
+
+    emitDone({ fileCount: 1 })
+    emitDone({ fileCount: 99 })
+
+    await expect(promise).resolves.toMatchObject({ fileCount: 1 })
+
+    const doneCalls = onProgress.mock.calls.filter(
+      ([msg]) => msg.response === 'done',
+    )
+    expect(doneCalls).toHaveLength(1)
   })
 })

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolve after `ms` milliseconds.
+ *
+ * Both callers run under fake timers in their tests, so this must stay a bare
+ * setTimeout with no ambient clock reads.
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/fetchWithRetry.ts
+++ b/src/fetchWithRetry.ts
@@ -10,6 +10,8 @@
  * backpressure — workers block during backoff, reducing concurrent uploads.
  */
 
+import { delay } from './delay'
+
 const MAX_ATTEMPTS = 5
 const BASE_DELAY_MS = 1000
 const BACKOFF_MULTIPLIER = 3
@@ -32,7 +34,7 @@ export async function fetchWithRetry(
       console.warn(
         `fetch attempt ${attempt}/${MAX_ATTEMPTS} failed: ${(error as TypeError).message}. Retrying in ${delayMs}ms...`,
       )
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      await delay(delayMs)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,15 @@ import {
   dispatchMappingJobs,
   filesToProcess,
   getLastWorkerProgressTime,
+  getPendingReplacements,
+  getQueueLength,
   getWorkerCurrentFile,
   getWorkersActive,
   initializeMappingWorkers,
+  isDirectoryScanFinished,
   markScanPaused,
   type ProgressCallback,
+  resetWorkerProgressTime,
   scanAnomalies,
   setAbortSignal,
   setCustomUploader,
@@ -97,6 +101,12 @@ async function initializeFileListWorker(
   fileListWorker.addEventListener(
     'message',
     (event: MessageEvent<FileScanMsg>) => {
+      // A live scanner is progress too: without this, any long stretch that
+      // yields no mappable files -- a deep tree of excluded filetypes, a slow
+      // remote listing -- is reported as a stall. A wedged pump still trips the
+      // watchdog, because the scanner pauses on backpressure and goes quiet.
+      resetWorkerProgressTime()
+
       switch (event.data.response) {
         case 'file': {
           const { fileInfo, previousFileInfo } = event.data
@@ -269,6 +279,9 @@ function queueFilesForMapping(
   })
   // Dispatch jobs once after all files are queued to prevent race conditions
   dispatchMappingJobs()
+  // No scan runs for this input type, so nothing else would ever satisfy the
+  // termination condition and curateMany would never settle.
+  setDirectoryScanFinished(true)
 }
 
 function queueUrlsForMapping(
@@ -310,46 +323,81 @@ async function curateMany(
 
     const signal = organizeOptions.signal
 
-    // Stall watchdog: if no mapping worker at all has reported back for 10
-    // minutes (i.e., all active workers are stuck), terminate them and count
-    // their in-flight files as mapping errors. This guards against undetectable
-    // worker crashes (e.g., OOM kills that don't trigger onerror or on('exit')).
+    // Stall watchdog: if nothing has reported back for 10 minutes while work
+    // is still outstanding, recover any stuck workers (counting their in-flight
+    // files as mapping errors) and re-pump the dispatch loop. Guards against
+    // crashes no handler sees (e.g. OOM kills) and against a lost dispatch.
     const STALL_TIMEOUT_MS = 10 * 60 * 1000
     const stallWatchdog = setInterval(() => {
+      if (Date.now() - getLastWorkerProgressTime() <= STALL_TIMEOUT_MS) return
+
+      // Gating on active workers alone misses the worst case: a dispatch loop
+      // killed between `workersActive -= 1` and the re-dispatch leaves zero
+      // workers active with the queue still full and the scanner paused, since
+      // backpressure is only released from inside dispatchMappingJobs().
+      // Mirrors the pool's 4-way termination condition exactly, replacements
+      // included: a replacement worker that never finishes being created stalls
+      // a run that otherwise looks complete, and dropping that term here would
+      // silence the one signal that reports it.
+      const workersActive = getWorkersActive()
+      const queueLength = getQueueLength()
+      const scanFinished = isDirectoryScanFinished()
+      const pendingReplacements = getPendingReplacements()
       if (
-        getWorkersActive() > 0 &&
-        Date.now() - getLastWorkerProgressTime() > STALL_TIMEOUT_MS
+        workersActive === 0 &&
+        queueLength === 0 &&
+        scanFinished &&
+        pendingReplacements === 0
       ) {
-        console.error(
-          `Stall detected: ${getWorkersActive()} mapping worker(s) have not responded for 10 minutes.`,
-        )
-        const workerCurrentFile = getWorkerCurrentFile()
-        // Recover all stuck workers. Iterate over a copy since
-        // recoverCrashedWorker modifies workerCurrentFile.
-        for (const [worker] of [...workerCurrentFile]) {
-          // Import recoverCrashedWorker indirectly via the worker's onerror.
-          // The onerror handler calls recoverCrashedWorker internally.
-          if (worker.onerror) {
-            // Synthetic error event -- avoid ErrorEvent constructor which is
-            // unavailable in Node.js < 23. The onerror handler only reads
-            // event.message via duck-typing so a plain object suffices.
-            worker.onerror({
-              message: 'Worker stalled (no response for 10 minutes)',
-            } as unknown as ErrorEvent)
-          }
+        return
+      }
+
+      console.error(
+        `Stall detected: no mapping progress for 10 minutes (${workersActive} worker(s) active, ${queueLength} file(s) queued, ${pendingReplacements} replacement(s) pending, scan ${scanFinished ? 'finished' : 'in progress'}).`,
+      )
+
+      const workerCurrentFile = getWorkerCurrentFile()
+      // Recover all stuck workers. Iterate over a copy since
+      // recoverCrashedWorker modifies workerCurrentFile.
+      for (const [worker] of [...workerCurrentFile]) {
+        // Import recoverCrashedWorker indirectly via the worker's onerror.
+        // The onerror handler calls recoverCrashedWorker internally.
+        if (worker.onerror) {
+          // Synthetic error event -- avoid ErrorEvent constructor which is
+          // unavailable in Node.js < 23. The onerror handler only reads
+          // event.message via duck-typing so a plain object suffices.
+          worker.onerror({
+            message: 'Worker stalled (no response for 10 minutes)',
+          } as unknown as ErrorEvent)
         }
       }
+
+      // Unconditional: when the stall is a lost dispatch rather than a stuck
+      // worker there is nothing for the loop above to recover, and this is the
+      // only call that drains the queue and releases scanner backpressure.
+      void dispatchMappingJobs()
+
+      resetWorkerProgressTime()
     }, 60_000)
 
     // Progress callback wraps the user's callback and handles lifecycle
     const progressCallback: ProgressCallback = (msg) => {
-      onProgress?.(msg)
-
-      if (msg.response === 'done' && !settled) {
+      if (msg.response === 'done') {
+        // Settle first: a consumer that throws must not be able to stop
+        // curateMany from resolving, and 'done' is forwarded at most once.
+        if (settled) return
         settled = true
         clearInterval(stallWatchdog)
         signal?.removeEventListener('abort', onAbort)
         resolve(msg)
+      }
+
+      // resolve() only queues the awaiter as a microtask, so a synchronous
+      // consumer still observes 'done' before the caller of curateMany resumes.
+      try {
+        onProgress?.(msg)
+      } catch (error) {
+        console.error('Error in curateMany progress callback:', error)
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { composeSpecs } from './composeSpecs'
 import { extractColumnMappings, type TColumnMappings } from './csvMapping'
 import { curateOne } from './curateOne'
 import {
-  availableMappingWorkers,
   dispatchMappingJobs,
   filesToProcess,
   getLastMappingProgressTime,
@@ -79,7 +78,9 @@ function requiresDateOffset(
  */
 // TODO: implement a buffering stream to request fileHandles in batches
 async function initializeFileListWorker(
-  rejectCallback: (reason: Error) => void,
+  // Must be failRun, not rejectCallback: every failure path below ends a run
+  // that still owns a mapping worker pool, and only failRun tears it down.
+  failRun: (reason: Error) => void,
   isRunOver: () => boolean,
 ) {
   const fileListWorker = await createWorker(
@@ -89,11 +90,7 @@ async function initializeFileListWorker(
 
   fileListWorker.onerror = (error) => {
     console.error('Scan worker crashed:', error)
-    // Terminate all mapping workers (both idle and active)
-    while (availableMappingWorkers.length) {
-      availableMappingWorkers.pop()!.terminate()
-    }
-    rejectCallback(
+    failRun(
       new Error(
         `Scan worker crashed: ${'message' in error ? (error as { message: string }).message : String(error)}`,
       ),
@@ -117,9 +114,7 @@ async function initializeFileListWorker(
       // would make a dead run's exit look live again.
       if (code === 0 || isDirectoryScanFinished() || isRunOver()) return
       console.error(`Scan worker exited unexpectedly with code ${code}`)
-      rejectCallback(
-        new Error(`Scan worker exited unexpectedly with code ${code}`),
-      )
+      failRun(new Error(`Scan worker exited unexpectedly with code ${code}`))
     })
   }
 
@@ -173,11 +168,7 @@ async function initializeFileListWorker(
         case 'error': {
           console.error('Scan worker error:', event.data.error)
           fileListWorker.terminate()
-          // Terminate all mapping workers (both idle and active)
-          while (availableMappingWorkers.length) {
-            availableMappingWorkers.pop()!.terminate()
-          }
-          rejectCallback(new Error(event.data.error))
+          failRun(new Error(event.data.error))
           break
         }
         default: {
@@ -350,6 +341,12 @@ async function curateMany(
     // Prevents double-settle when abort races with natural completion.
     let settled = false
 
+    // Whether a scan was ever requested for this run. The watchdog's
+    // no-mapping-work branch also holds before the scan request is posted, and
+    // permanently for an inputType that starts no scanner, so it must not
+    // report either as a scanner going quiet.
+    let scanRequested = false
+
     const signal = organizeOptions.signal
 
     // Stall watchdog: if there's outstanding work and no progress relevant to
@@ -399,7 +396,11 @@ async function curateMany(
         // minutes of silence in that state means it is never coming back, and
         // waiting forever is the failure this watchdog exists to end.
         failRun(
-          new Error('Scan worker stopped reporting progress for 10 minutes'),
+          new Error(
+            scanRequested
+              ? 'Scan worker stopped reporting progress for 10 minutes'
+              : 'No mapping work and no directory scan in progress for 10 minutes',
+          ),
         )
         return
       }
@@ -540,14 +541,23 @@ async function curateMany(
           organizeOptions.inputType === 'path' ||
           organizeOptions.inputType === 's3'
         ) {
-          // Checked again: an initError landing during the awaits above
-          // rejects the run, and a scan worker started for it would run the
-          // whole tree with nothing left able to terminate it.
+          // Checked again after the await:
+          // until the assignment completes, failRun and onAbort see
+          // fileListWorker as undefined and their terminate() is a no-op, so a
+          // run that settles during creation can only be cleaned up here.
           if (settled) return
           fileListWorker = await initializeFileListWorker(
             failRun,
             () => settled,
           )
+          if (settled) {
+            try {
+              fileListWorker.terminate()
+            } catch {
+              // already terminated
+            }
+            return
+          }
 
           // Wire up backpressure resume: when the dispatch loop drains the
           // queue below the low-water mark, it calls this to resume scanning.
@@ -604,6 +614,7 @@ async function curateMany(
               noDefaultExclusions,
             } satisfies FileScanRequest)
           }
+          scanRequested = true
         } else if (organizeOptions.inputType === 'files') {
           queueFilesForMapping(organizeOptions)
         } else if (organizeOptions.inputType === 'http') {
@@ -614,7 +625,10 @@ async function curateMany(
 
         dispatchMappingJobs()
       } catch (error) {
-        rejectCallback(error as Error)
+        // failRun, not rejectCallback: collectMappingOptions and the spec
+        // composition can both throw after the pool is built. Rejecting alone
+        // leaves those workers running, holding the Node event loop open.
+        failRun(error as Error)
       }
     })()
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,11 +277,12 @@ function queueFilesForMapping(
       scanAnomalies: [],
     })
   })
+  // No scan runs for this input type, so nothing else would ever satisfy the
+  // termination condition and curateMany would never settle. Set before
+  // dispatching so settling never depends on a dispatch call elsewhere.
+  setDirectoryScanFinished(true)
   // Dispatch jobs once after all files are queued to prevent race conditions
   dispatchMappingJobs()
-  // No scan runs for this input type, so nothing else would ever satisfy the
-  // termination condition and curateMany would never settle.
-  setDirectoryScanFinished(true)
 }
 
 function queueUrlsForMapping(
@@ -302,8 +303,10 @@ function queueUrlsForMapping(
     })
   })
 
-  dispatchMappingJobs()
+  // No scan runs for this input type either; set before dispatching for the
+  // same reason as queueFilesForMapping above.
   setDirectoryScanFinished(true)
+  dispatchMappingJobs()
 }
 
 async function curateMany(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   getWorkerCurrentFile,
   getWorkersActive,
   initializeMappingWorkers,
+  isAborted,
   isDirectoryScanFinished,
   markScanPaused,
   type ProgressCallback,
@@ -97,6 +98,26 @@ async function initializeFileListWorker(
         `Scan worker crashed: ${'message' in error ? (error as { message: string }).message : String(error)}`,
       ),
     )
+  }
+
+  // Node worker_threads reports some deaths (OOM kill, unhandled rejection in
+  // the thread) only via 'exit', never onerror. Without this the run waits
+  // forever on a scanner that no longer exists: the watchdog can log the stall
+  // but has nothing to recover and no way to settle.
+  if ('on' in fileListWorker) {
+    ;(
+      fileListWorker as unknown as {
+        on(event: string, cb: (code: number) => void): void
+      }
+    ).on('exit', (code: number) => {
+      // Code 0 is a normal exit; a non-zero code after the scan finished, or
+      // after an abort's terminate(), is intentional.
+      if (code === 0 || isDirectoryScanFinished() || isAborted()) return
+      console.error(`Scan worker exited unexpectedly with code ${code}`)
+      rejectCallback(
+        new Error(`Scan worker exited unexpectedly with code ${code}`),
+      )
+    })
   }
 
   fileListWorker.addEventListener(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import {
   getWorkerCurrentFile,
   getWorkersActive,
   initializeMappingWorkers,
-  isAborted,
   isDirectoryScanFinished,
   markScanPaused,
   type ProgressCallback,
@@ -81,6 +80,7 @@ function requiresDateOffset(
 // TODO: implement a buffering stream to request fileHandles in batches
 async function initializeFileListWorker(
   rejectCallback: (reason: Error) => void,
+  isRunOver: () => boolean,
 ) {
   const fileListWorker = await createWorker(
     new URL('./scanDirectoryWorker.js', import.meta.url),
@@ -111,8 +111,11 @@ async function initializeFileListWorker(
       }
     ).on('exit', (code: number) => {
       // Code 0 is a normal exit; a non-zero code after the scan finished, or
-      // after an abort's terminate(), is intentional.
-      if (code === 0 || isDirectoryScanFinished() || isAborted()) return
+      // after this run ended (its own abort terminated the worker), is
+      // intentional. `isRunOver` is scoped to the run that owns this worker:
+      // the pool's abort flag is module-global, so a later run resetting it
+      // would make a dead run's exit look live again.
+      if (code === 0 || isDirectoryScanFinished() || isRunOver()) return
       console.error(`Scan worker exited unexpectedly with code ${code}`)
       rejectCallback(
         new Error(`Scan worker exited unexpectedly with code ${code}`),
@@ -387,6 +390,20 @@ async function curateMany(
         `Stall detected: no ${mappingWorkOutstanding ? 'mapping' : 'scan'} progress for 10 minutes (${workersActive} worker(s) active, ${queueLength} file(s) queued, ${pendingReplacements} replacement(s) pending, scan ${scanFinished ? 'finished' : 'in progress'}).`,
       )
 
+      if (!mappingWorkOutstanding) {
+        // Waiting on a scanner that has gone quiet, with nothing dispatched
+        // and nothing queued: there is no worker to recover and no file to
+        // re-dispatch, so the loop below and the re-pump can do nothing. The
+        // scanner is not paused either — backpressure only pauses it while the
+        // queue is full, which would have made mapping work outstanding. Ten
+        // minutes of silence in that state means it is never coming back, and
+        // waiting forever is the failure this watchdog exists to end.
+        failRun(
+          new Error('Scan worker stopped reporting progress for 10 minutes'),
+        )
+        return
+      }
+
       const workerCurrentFile = getWorkerCurrentFile()
       // Recover all stuck workers. Iterate over a copy since
       // recoverCrashedWorker modifies workerCurrentFile.
@@ -527,7 +544,10 @@ async function curateMany(
           // rejects the run, and a scan worker started for it would run the
           // whole tree with nothing left able to terminate it.
           if (settled) return
-          fileListWorker = await initializeFileListWorker(failRun)
+          fileListWorker = await initializeFileListWorker(
+            failRun,
+            () => settled,
+          )
 
           // Wire up backpressure resume: when the dispatch loop drains the
           // queue below the low-water mark, it calls this to resume scanning.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,17 @@ import {
   availableMappingWorkers,
   dispatchMappingJobs,
   filesToProcess,
-  getLastWorkerProgressTime,
+  getLastMappingProgressTime,
+  getLastScanProgressTime,
   getPendingReplacements,
-  getQueueLength,
   getWorkerCurrentFile,
   getWorkersActive,
   initializeMappingWorkers,
   isDirectoryScanFinished,
   markScanPaused,
   type ProgressCallback,
-  resetWorkerProgressTime,
+  resetProgressTimestamps,
+  resetScanProgressTime,
   scanAnomalies,
   setAbortSignal,
   setCustomUploader,
@@ -101,11 +102,12 @@ async function initializeFileListWorker(
   fileListWorker.addEventListener(
     'message',
     (event: MessageEvent<FileScanMsg>) => {
-      // A live scanner is progress too: without this, any long stretch that
-      // yields no mappable files -- a deep tree of excluded filetypes, a slow
-      // remote listing -- is reported as a stall. A wedged pump still trips the
-      // watchdog, because the scanner pauses on backpressure and goes quiet.
-      resetWorkerProgressTime()
+      // A live scanner is progress too: without this, a long stretch that
+      // yields no mappable files (deep excluded tree, slow remote listing)
+      // reads as a stall. Refreshes only the scan baseline: the file counter
+      // runs even while paused for backpressure, so it must never be able to
+      // mask a wedged mapping pump.
+      resetScanProgressTime()
 
       switch (event.data.response) {
         case 'file': {
@@ -326,14 +328,12 @@ async function curateMany(
 
     const signal = organizeOptions.signal
 
-    // Stall watchdog: if nothing has reported back for 10 minutes while work
-    // is still outstanding, recover any stuck workers (counting their in-flight
+    // Stall watchdog: if there's outstanding work and no progress relevant to
+    // it for 10 minutes, recover any stuck workers (counting their in-flight
     // files as mapping errors) and re-pump the dispatch loop. Guards against
     // crashes no handler sees (e.g. OOM kills) and against a lost dispatch.
     const STALL_TIMEOUT_MS = 10 * 60 * 1000
     const stallWatchdog = setInterval(() => {
-      if (Date.now() - getLastWorkerProgressTime() <= STALL_TIMEOUT_MS) return
-
       // Gating on active workers alone misses the worst case: a dispatch loop
       // killed between `workersActive -= 1` and the re-dispatch leaves zero
       // workers active with the queue still full and the scanner paused, since
@@ -343,20 +343,27 @@ async function curateMany(
       // a run that otherwise looks complete, and dropping that term here would
       // silence the one signal that reports it.
       const workersActive = getWorkersActive()
-      const queueLength = getQueueLength()
+      const queueLength = filesToProcess.length
       const scanFinished = isDirectoryScanFinished()
       const pendingReplacements = getPendingReplacements()
-      if (
-        workersActive === 0 &&
-        queueLength === 0 &&
-        scanFinished &&
-        pendingReplacements === 0
-      ) {
+      const mappingWorkOutstanding =
+        workersActive > 0 || queueLength > 0 || pendingReplacements > 0
+      if (!mappingWorkOutstanding && scanFinished) {
         return
       }
 
+      // With mapping work outstanding, only mapping activity counts: the
+      // scanner's file counter runs even while paused for backpressure, so
+      // scan activity could mask a dead pump for the rest of the scan. Fall
+      // back to the scan timestamp only when the run is purely waiting on
+      // the scanner to surface more files.
+      const relevantProgressTime = mappingWorkOutstanding
+        ? getLastMappingProgressTime()
+        : getLastScanProgressTime()
+      if (Date.now() - relevantProgressTime <= STALL_TIMEOUT_MS) return
+
       console.error(
-        `Stall detected: no mapping progress for 10 minutes (${workersActive} worker(s) active, ${queueLength} file(s) queued, ${pendingReplacements} replacement(s) pending, scan ${scanFinished ? 'finished' : 'in progress'}).`,
+        `Stall detected: no ${mappingWorkOutstanding ? 'mapping' : 'scan'} progress for 10 minutes (${workersActive} worker(s) active, ${queueLength} file(s) queued, ${pendingReplacements} replacement(s) pending, scan ${scanFinished ? 'finished' : 'in progress'}).`,
       )
 
       const workerCurrentFile = getWorkerCurrentFile()
@@ -380,7 +387,7 @@ async function curateMany(
       // only call that drains the queue and releases scanner backpressure.
       void dispatchMappingJobs()
 
-      resetWorkerProgressTime()
+      resetProgressTimestamps()
     }, 60_000)
 
     // Progress callback wraps the user's callback and handles lifecycle

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,20 @@ async function curateMany(
     // terminate it. Assigned later when a directory/path/s3 input is used.
     let fileListWorker: Worker | undefined
 
+    // For failures that leave nothing to wait for (scan worker death, every
+    // mapping worker failing to initialize). Guarded on settled so a stale
+    // event from a finished run cannot tear down a newer one's pool state.
+    const failRun = (reason: Error) => {
+      if (settled) return
+      try {
+        fileListWorker?.terminate()
+      } catch {
+        /* already terminated */
+      }
+      terminateAllWorkers()
+      rejectCallback(reason)
+    }
+
     const onAbort = () => {
       // Terminate the scan worker if it exists
       try {
@@ -460,7 +474,13 @@ async function curateMany(
           organizeOptions.fileInfoIndex,
           progressCallback,
           organizeOptions.workerCount,
+          failRun,
         )
+
+        // The pool can reject the run from inside that call (every worker
+        // failed to initialize). Both failRun and onAbort are settled-guarded,
+        // so anything created past this point could never be torn down.
+        if (settled) return
 
         // Set global mappingWorkerOptions
         setMappingWorkerOptions(
@@ -482,7 +502,11 @@ async function curateMany(
           organizeOptions.inputType === 'path' ||
           organizeOptions.inputType === 's3'
         ) {
-          fileListWorker = await initializeFileListWorker(rejectCallback)
+          // Checked again: an initError landing during the awaits above
+          // rejects the run, and a scan worker started for it would run the
+          // whole tree with nothing left able to terminate it.
+          if (settled) return
+          fileListWorker = await initializeFileListWorker(failRun)
 
           // Wire up backpressure resume: when the dispatch loop drains the
           // queue below the low-water mark, it calls this to resume scanning.

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -1,5 +1,6 @@
 import {
   configureMockMappingWorkers,
+  getMockWorkersCreated,
   getNextMockBehavior,
   MockWorker,
   registerMockWorker,
@@ -8,12 +9,20 @@ import {
 
 let pauseHeaders = false
 let resumeHeaders: (() => void) | null = null
+let failPausedHeaders: (() => void) | null = null
+let rejectNextHeaders = false
 
 vi.doMock('./httpHeaders', () => ({
   getHttpInputHeaders: vi.fn(async (fileInfo: any) => {
+    if (rejectNextHeaders) {
+      rejectNextHeaders = false
+      throw new Error('Header provider unavailable')
+    }
     if (pauseHeaders) {
-      await new Promise<void>((resolve) => {
+      await new Promise<void>((resolve, reject) => {
         resumeHeaders = resolve
+        failPausedHeaders = () =>
+          reject(new Error('Header provider unavailable'))
       })
     }
     return fileInfo
@@ -42,10 +51,32 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve()
 }
 
+/** Let any already-scheduled setTimeout(0) work run to completion. */
+async function settle(): Promise<void> {
+  for (let tick = 0; tick < 10; tick++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+/** Drive real timers until `predicate` holds; the mock workers reply on setTimeout(0). */
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let tick = 0; tick < 200; tick++) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('waitFor: condition was never met')
+}
+
+function queueFile(name: string) {
+  return { fileInfo: makeFileInfo(name), scanAnomalies: [] }
+}
+
 describe('dispatchMappingJobs', () => {
   beforeEach(() => {
     pauseHeaders = false
     resumeHeaders = null
+    failPausedHeaders = null
+    rejectNextHeaders = false
     resetMockWorkers()
   })
 
@@ -97,5 +128,206 @@ describe('dispatchMappingJobs', () => {
     // Unblock header resolution so the first dispatch can finish cleanly.
     resumeHeaders?.()
     await dispatchPromise
+  })
+
+  it('keeps pumping when the consumer progress callback throws', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      true,
+      undefined,
+      (msg: any) => {
+        progressMessages.push(msg)
+        throw new Error('consumer callback exploded')
+      },
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    pool.filesToProcess.push(queueFile('a.dcm'), queueFile('b.dcm'))
+
+    // The throw must not escape dispatch either: every caller invokes
+    // dispatchMappingJobs() unawaited, so a rejection would go unhandled.
+    await expect(pool.dispatchMappingJobs()).resolves.toBeUndefined()
+
+    await waitFor(() => progressMessages.some((m) => m.response === 'done'))
+
+    // Both files reported and the run finished: without the guard the first
+    // 'finished' would kill the pump with the second file still queued.
+    expect(
+      progressMessages.filter((m) => m.response === 'progress'),
+    ).toHaveLength(2)
+    expect(progressMessages.at(-1).processedFiles).toBe(2)
+    expect(pool.getWorkersActive()).toBe(0)
+  })
+
+  it('errors the file and returns the worker when header resolution rejects', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    // LIFO dispatch: the last file pushed is the one whose headers reject.
+    pool.filesToProcess.push(queueFile('mapped.dcm'), queueFile('rejected.dcm'))
+    rejectNextHeaders = true
+
+    await pool.dispatchMappingJobs()
+    await waitFor(() => progressMessages.some((m) => m.response === 'done'))
+
+    const done = progressMessages.at(-1)
+    expect(done.processedFiles).toBe(2)
+
+    // The popped file is accounted for as an error carrying its fileInfo,
+    // rather than disappearing along with the worker slot.
+    const failed = done.mapResultsList.find(
+      (r: any) => r.fileInfo?.name === 'rejected.dcm',
+    )
+    expect(failed.errors).toEqual(['Header provider unavailable'])
+
+    // The second file could only be dispatched because the worker went back
+    // to the pool, so this is the assertion that the slot was not leaked.
+    const mapped = done.mapResultsList.find(
+      (r: any) => r.fileInfo?.name === 'mapped.dcm',
+    )
+    expect(mapped.errors).toEqual([])
+    expect(pool.getWorkersActive()).toBe(0)
+  })
+
+  it('does not free a still-busy worker on an unrecognised message', async () => {
+    // The mock replies with an unknown message and then finishes the file, so
+    // returning the worker to the pool would count that file twice and drive
+    // workersActive negative -- past which the termination check never holds.
+    configureMockMappingWorkers(['unknown-response'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    // Scan deliberately left unfinished: reaching 'done' would terminate the
+    // pooled worker and mask the late reply this guards against.
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    await pool.dispatchMappingJobs()
+    await waitFor(() => progressMessages.length > 0)
+    await settle()
+
+    // One file in, one result out: a second means the worker replied after
+    // being freed.
+    expect(progressMessages).toHaveLength(1)
+    expect(progressMessages[0].processedFiles).toBe(1)
+    expect(pool.getWorkersActive()).toBe(0)
+    // The replacement, not the original returned twice.
+    expect(pool.availableMappingWorkers).toHaveLength(1)
+  })
+
+  it('leaves the pool clean when the run is aborted during header resolution', async () => {
+    pauseHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    const dispatchPromise = pool.dispatchMappingJobs()
+    await flushMicrotasks()
+
+    // Abort mid-await, then fail the header request as a cancelled provider
+    // would. The pool is torn down by the time the rejection lands.
+    pool.terminateAllWorkers()
+    failPausedHeaders?.()
+    await dispatchPromise
+
+    // A terminated worker put back here would be handed a file by the *next*
+    // run and never reply, and a negative count would break its termination.
+    expect(pool.availableMappingWorkers).toHaveLength(0)
+    expect(pool.getWorkersActive()).toBe(0)
+    expect(progressMessages).toHaveLength(0)
+  })
+
+  it('does not re-account a file the stall watchdog already recovered', async () => {
+    pauseHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    // Left unfinished so the run cannot terminate and tear the pool down
+    // before the late rejection lands.
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    const dispatchPromise = pool.dispatchMappingJobs()
+    await flushMicrotasks()
+
+    // The watchdog reaches the worker through onerror while the dispatch loop
+    // is still awaiting its headers -- the file is accounted for here.
+    const [stuck] = getMockWorkersCreated()
+    stuck.onerror!({ message: 'Worker stalled (no response for 10 minutes)' })
+    await settle()
+
+    // Only now does the header request fail, for the same underlying reason.
+    failPausedHeaders?.()
+    await dispatchPromise
+    await settle()
+
+    expect(progressMessages).toHaveLength(1)
+    expect(progressMessages[0].processedFiles).toBe(1)
+    expect(pool.getWorkersActive()).toBe(0)
+    // The replacement only. The recovered worker was terminated, so putting it
+    // back would hand the next dispatch a worker that can never reply.
+    expect(pool.availableMappingWorkers).toHaveLength(1)
+    expect(pool.availableMappingWorkers[0]).not.toBe(stuck)
+  })
+
+  it('emits done once when dispatch is re-entered in a terminal state', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    pool.scanAnomalies.push({
+      fileInfo: makeFileInfo('unreadable.dcm'),
+      anomalies: [],
+      errors: ['Simulated read failure'],
+    })
+
+    await pool.dispatchMappingJobs()
+    await pool.dispatchMappingJobs()
+
+    const doneMessages = progressMessages.filter((m) => m.response === 'done')
+    expect(doneMessages).toHaveLength(1)
+    // The consumer already holds this array, so a second pass through the
+    // termination block would corrupt results it has already been given.
+    expect(doneMessages[0].mapResultsList).toHaveLength(1)
   })
 })

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -221,6 +221,42 @@ describe('dispatchMappingJobs', () => {
     expect(pool.getWorkersActive()).toBe(0)
   })
 
+  // A run with a scattered handful of unreadable files must not pay for the
+  // streak machinery: at a 5% failure rate a flat per-failure delay costs a
+  // 100k-file run the best part of an hour in pure waiting.
+  it('does not delay dispatch after an isolated failure', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    // LIFO dispatch: the last file pushed is the one whose headers reject, so
+    // the good file behind it is dispatched from a live streak of one.
+    pool.filesToProcess.push(queueFile('mapped.dcm'), queueFile('rejected.dcm'))
+    rejectNextHeaders = true
+
+    vi.useFakeTimers()
+    try {
+      // Not one tick of the clock: had the failure booked a backoff, the
+      // second file could not be dispatched and this would never settle.
+      await pool.dispatchMappingJobs()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(pool.filesToProcess).toHaveLength(0)
+    expect(progressMessages).toHaveLength(1)
+    expect(progressMessages[0].mapResults.errors).toEqual([
+      'Header provider unavailable',
+    ])
+  })
+
   // The stall watchdog's only evidence that the mapping pump is alive. A pool
   // erroring files through the dispatch-failure path reaches none of the
   // handlers that refresh it, so without this it reads as dead and the watchdog
@@ -258,6 +294,9 @@ describe('dispatchMappingJobs', () => {
 
     const rejections: Error[] = []
     const progressMessages: any[] = []
+    // Captured before the teardown below empties it, so this measures the pool
+    // and not the test's own reject callback.
+    let queuedAtReport = -1
     await pool.initializeMappingWorkers(
       false,
       undefined,
@@ -267,6 +306,7 @@ describe('dispatchMappingJobs', () => {
       // the loop, so the file count below is the damage a streak really does.
       (reason: Error) => {
         rejections.push(reason)
+        queuedAtReport = pool.filesToProcess.length
         pool.terminateAllWorkers()
       },
     )
@@ -290,20 +330,161 @@ describe('dispatchMappingJobs', () => {
     // Once per streak, not once per failed file: the run owner tears the pool
     // down on the first report, and a success would reset the count.
     expect(rejections).toHaveLength(1)
-    expect(rejections[0].message).toMatch(
-      /Dispatch failed for 2\d+ consecutive/,
+    expect(rejections[0].message).toMatch(/Dispatch failed for 2\d consecutive/)
+    // The point of the backoff: a 200-file queue loses about twenty-five files,
+    // not all of them, before the run is failed. Most of the queue is still
+    // there when the report fires -- that is what makes the report worth acting
+    // on rather than a postmortem.
+    expect(progressMessages.length).toBeLessThanOrEqual(30)
+    expect(queuedAtReport).toBeGreaterThan(150)
+  })
+
+  // dispatchMappingJobs() runs once per scan-worker message, twice for 'file',
+  // so a streak during a live scan is re-entered continuously. Every entrant
+  // has to defer, and only one of them may retry: a backoff that only slowed
+  // the loop already sleeping lost 1051 files here instead of ~25, because each
+  // new entrant found the failed worker already back in the pool.
+  // Both counts, because the bound has to come from the streak and not from the
+  // pool: letting every idle worker retry in lockstep would multiply the loss
+  // by the pool size.
+  it.each([
+    1, 8,
+  ])('bounds the loss when dispatch is re-entered throughout the streak (%i workers)', async (workerCount) => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const rejections: Error[] = []
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      workerCount,
+      (reason: Error) => {
+        rejections.push(reason)
+        pool.terminateAllWorkers()
+      },
     )
-    // The point of the retry delay: a 200-file queue loses about twenty files,
-    // not all of them, before the run is failed.
-    expect(progressMessages.length).toBeLessThanOrEqual(25)
-    expect(pool.filesToProcess).toHaveLength(0)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 5000; i++) {
+      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
+    }
+
+    vi.useFakeTimers()
+    try {
+      void pool.dispatchMappingJobs()
+      // A scanner feeding steadily: ten re-entries per 100ms for the whole
+      // streak.
+      for (let tick = 0; tick < 150; tick++) {
+        for (let call = 0; call < 10; call++) void pool.dispatchMappingJobs()
+        await vi.advanceTimersByTimeAsync(100)
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(rejections).toHaveLength(1)
+    // 25 files at one worker, 29 at eight: the pool size adds a small
+    // constant, because up to N attempts are already in flight before the
+    // first failure registers, but it is not a multiplier. Unbounded, this
+    // queue loses over a thousand.
+    expect(progressMessages.length).toBeLessThanOrEqual(40)
+    // The queue is never empty during the streak, so nothing may report the
+    // run finished while the pool sits in a backoff with no worker active.
+    expect(
+      progressMessages.filter((m: any) => m.response === 'done'),
+    ).toHaveLength(0)
+  })
+
+  // Reporting is advice, not teardown: rejectCb is optional, and the paths that
+  // do wire it do not all terminate the pool. A backoff that switched itself
+  // off once reported let the rest of the queue burn at full speed.
+  it('keeps backing off after reporting when nothing tears the pool down', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    // No rejectCb: the pool has nothing to report to and nothing tears it down.
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 500; i++) {
+      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
+    }
+
+    vi.useFakeTimers()
+    try {
+      void pool.dispatchMappingJobs()
+      // Well past the report, which lands around 10s.
+      await vi.advanceTimersByTimeAsync(20_000)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // Capped by the backoff throughout, not just up to the report: 20s of
+    // 500ms ceiling is ~45 files, nowhere near the whole queue.
+    expect(progressMessages.length).toBeLessThanOrEqual(60)
+    expect(pool.filesToProcess.length).toBeGreaterThan(400)
   })
 
   // A token refresh that blips for a few seconds fails a burst of files. The
   // provider comes back before the streak is old enough to count, and tearing
   // the whole run down over it would cost hours of completed work.
+  //
+  // The burst deliberately runs past MAX_CONSECUTIVE_DISPATCH_FAILURES: with
+  // the count gate already satisfied, only the duration gate is left to stop
+  // the report, which is the one this test exists to hold.
   it('does not fail the run when a failure burst is over quickly', async () => {
     rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const rejections: Error[] = []
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 60; i++) {
+      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
+    }
+
+    vi.useFakeTimers()
+    try {
+      const dispatchPromise = pool.dispatchMappingJobs()
+      // Just under MIN_DISPATCH_FAILURE_STREAK_MS.
+      await vi.advanceTimersByTimeAsync(9_000)
+      rejectAllHeaders = false
+      await vi.advanceTimersByTimeAsync(9_000)
+      await dispatchPromise
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(rejections).toEqual([])
+    // Without this the burst could be short enough for the count gate to be
+    // what held, and the duration gate would be free to disappear.
+    const errored = progressMessages.filter(
+      (m: any) => m.mapResults?.errors?.length,
+    )
+    expect(errored.length).toBeGreaterThan(20)
+  })
+
+  // Failures arriving more slowly than the backoff -- a queue the scanner is
+  // only trickling into -- age past MIN_DISPATCH_FAILURE_STREAK_MS on their
+  // own. Nothing but the count gate stands between two unlucky files eleven
+  // seconds apart and a torn-down run.
+  it('does not fail the run on a couple of failures spread over a long window', async () => {
     configureMockMappingWorkers(['normal'])
 
     const rejections: Error[] = []
@@ -315,18 +496,23 @@ describe('dispatchMappingJobs', () => {
       (reason: Error) => rejections.push(reason),
     )
     pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
-    pool.setDirectoryScanFinished(true)
-    for (let i = 0; i < 40; i++) {
-      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
-    }
+    // Left unfinished so an empty queue does not emit 'done' and drain the pool
+    // between the two failures.
+    pool.setDirectoryScanFinished(false)
 
     vi.useFakeTimers()
     try {
-      const dispatchPromise = pool.dispatchMappingJobs()
-      await vi.advanceTimersByTimeAsync(4_000)
-      rejectAllHeaders = false
-      await vi.advanceTimersByTimeAsync(4_000)
-      await dispatchPromise
+      for (let i = 0; i < 2; i++) {
+        rejectAllHeaders = true
+        pool.filesToProcess.push(queueFile(`bad${i}.dcm`))
+        await pool.dispatchMappingJobs()
+        rejectAllHeaders = false
+        // No successful dispatch in between, so the streak is never reset --
+        // the second failure lands on a streak already older than
+        // MIN_DISPATCH_FAILURE_STREAK_MS, leaving the count gate alone to
+        // decide.
+        await vi.advanceTimersByTimeAsync(11_000)
+      }
     } finally {
       vi.useRealTimers()
     }

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -221,6 +221,33 @@ describe('dispatchMappingJobs', () => {
     expect(pool.getWorkersActive()).toBe(0)
   })
 
+  // The stall watchdog's only evidence that the mapping pump is alive. A pool
+  // erroring files through the dispatch-failure path reaches none of the
+  // handlers that refresh it, so without this it reads as dead and the watchdog
+  // reports a stall against a pool that is working perfectly hard.
+  it('counts a failed dispatch as mapping progress', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    await pool.initializeMappingWorkers(false, undefined, () => {}, 1)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+
+    vi.useFakeTimers()
+    try {
+      await vi.advanceTimersByTimeAsync(60_000)
+      const before = pool.getLastMappingProgressTime()
+
+      pool.filesToProcess.push(queueFile('bad.dcm'))
+      void pool.dispatchMappingJobs()
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(pool.getLastMappingProgressTime()).toBeGreaterThan(before)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('fails the run once dispatch has failed for a long enough streak', async () => {
     // getHttpOutputHeaders runs per file, so one expired token fails every
     // file in turn. Erroring each of them keeps 'done' reachable but turns a

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -552,3 +552,24 @@ describe('dispatchMappingJobs', () => {
     expect(doneMessages[0].mapResultsList).toHaveLength(1)
   })
 })
+
+describe('initializeMappingWorkers', () => {
+  beforeEach(() => {
+    resetMockWorkers()
+  })
+
+  afterEach(() => {
+    pool.terminateAllWorkers()
+  })
+
+  // An empty pool blames the workers for it: "All mapping workers failed to
+  // initialize: " with nothing after the colon, none having been created.
+  it('rejects a workerCount below one', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    await expect(
+      pool.initializeMappingWorkers(false, undefined, () => {}, 0),
+    ).rejects.toThrow('workerCount must be a positive integer, received 0')
+    expect(getMockWorkersCreated()).toHaveLength(0)
+  })
+})

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -13,6 +13,11 @@ let failPausedHeaders: (() => void) | null = null
 let rejectNextHeaders = false
 let rejectAllHeaders = false
 let failWorkerCreation = false
+// Number of workers that may still be built before creation starts failing.
+// null disables it; failWorkerCreation above is the all-or-nothing form.
+let workerCreationsBeforeFailure: number | null = null
+let pauseWorkerCreation = false
+let resumeWorkerCreation: (() => void) | null = null
 
 vi.doMock('./httpHeaders', () => ({
   getHttpInputHeaders: vi.fn(async (fileInfo: any) => {
@@ -39,6 +44,17 @@ vi.doMock('./worker', () => ({
   createWorker: vi.fn(async () => {
     if (failWorkerCreation) {
       throw new Error('Worker construction failed')
+    }
+    if (workerCreationsBeforeFailure !== null) {
+      if (workerCreationsBeforeFailure <= 0) {
+        throw new Error('Worker construction failed')
+      }
+      workerCreationsBeforeFailure -= 1
+    }
+    if (pauseWorkerCreation) {
+      await new Promise<void>((resolve) => {
+        resumeWorkerCreation = resolve
+      })
     }
     const mock = new MockWorker(getNextMockBehavior())
     registerMockWorker(mock)
@@ -91,6 +107,9 @@ function resetMockState(): void {
   rejectNextHeaders = false
   rejectAllHeaders = false
   failWorkerCreation = false
+  workerCreationsBeforeFailure = null
+  pauseWorkerCreation = false
+  resumeWorkerCreation = null
   resetMockWorkers()
 }
 
@@ -101,6 +120,9 @@ describe('dispatchMappingJobs', () => {
     // Unblock any pending header awaits so the event loop is clean.
     resumeHeaders?.()
     resumeHeaders = null
+    // Same for a worker creation a test left parked.
+    resumeWorkerCreation?.()
+    resumeWorkerCreation = null
     // availableMappingWorkers is module-global and initializeMappingWorkers
     // only pushes to it, so a worker one test leaves behind is dispatchable in
     // the next.
@@ -771,6 +793,354 @@ describe('dispatchMappingJobs', () => {
     // termination block would corrupt results it has already been given.
     expect(doneMessages[0].mapResultsList).toHaveLength(1)
   })
+
+  // The backoff gate sits between the while condition and the two pops, so
+  // both loop invariants can go stale across its sleep. No abort is needed for
+  // this one: a loop that entered before the streak began is not gated at all,
+  // and can drain the queue while this one waits.
+  it('recovers when the queue drains while dispatch sleeps in the backoff', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(
+      queueFile('a.dcm'),
+      queueFile('b.dcm'),
+      queueFile('c.dcm'),
+    )
+
+    vi.useFakeTimers()
+    try {
+      let dispatchError: unknown
+      const parked = pool.dispatchMappingJobs().catch((error: unknown) => {
+        dispatchError = error
+      })
+
+      // Two failures land: the first books no delay at all, and the second
+      // parks the loop in a 50ms backoff with a file still queued.
+      for (let tick = 0; tick < 5; tick++) {
+        await vi.advanceTimersByTimeAsync(1)
+      }
+      expect(progressMessages).toHaveLength(2)
+      expect(pool.filesToProcess).toHaveLength(1)
+
+      pool.filesToProcess.length = 0
+      await vi.advanceTimersByTimeAsync(100)
+      await parked
+
+      // Popping an empty queue throws, and every caller of dispatchMappingJobs
+      // invokes it unawaited -- on Node's default that is a process exit.
+      expect(dispatchError).toBeUndefined()
+
+      // A throw ahead of the try that releases the probe leaves it held by
+      // nobody, and every later call then breaks at the gate -- including the
+      // stall watchdog's recovery.
+      rejectAllHeaders = false
+      pool.filesToProcess.push(queueFile('d.dcm'))
+      await pool.dispatchMappingJobs()
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(pool.filesToProcess).toHaveLength(0)
+      expect(progressMessages).toHaveLength(3)
+      expect(progressMessages[2].mapResults.errors).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The same stale-invariant window, on the pool side: an idle worker can leave
+  // the pool during the sleep with nothing put back in its place, which is
+  // exactly what an idle 'initError' does by design.
+  it('never pools an undefined worker when the pool empties during the backoff', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(
+      queueFile('a.dcm'),
+      queueFile('b.dcm'),
+      queueFile('c.dcm'),
+    )
+
+    vi.useFakeTimers()
+    try {
+      let dispatchError: unknown
+      const parked = pool.dispatchMappingJobs().catch((error: unknown) => {
+        dispatchError = error
+      })
+      for (let tick = 0; tick < 5; tick++) {
+        await vi.advanceTimersByTimeAsync(1)
+      }
+      expect(pool.availableMappingWorkers).toHaveLength(1)
+
+      // The pooled worker reports that its environment never came up. That path
+      // removes it and deliberately spawns no replacement, so the pool is empty
+      // by the time the sleeping loop wakes.
+      const [worker] = getMockWorkersCreated()
+      ;(worker as any).emitMessage({
+        response: 'initError',
+        error: 'Simulated worker init failure',
+      })
+      expect(pool.availableMappingWorkers).toHaveLength(0)
+
+      await vi.advanceTimersByTimeAsync(100)
+      await parked
+
+      expect(dispatchError).toBeUndefined()
+      // `undefined` popped from an empty pool is dispatchable, and
+      // failFileAndReturnWorker puts it straight back after every failure.
+      expect(pool.availableMappingWorkers).not.toContain(undefined)
+      expect([...pool.getWorkerCurrentFile().keys()]).not.toContain(undefined)
+
+      // Worse than a run full of error results: the termination block latches
+      // doneEmitted before terminating the pool, so one throw on an `undefined`
+      // entry puts 'done' permanently out of reach.
+      pool.filesToProcess.length = 0
+      pool.setDirectoryScanFinished(true)
+      await pool.dispatchMappingJobs()
+      expect(
+        progressMessages.filter((m: any) => m.response === 'done'),
+      ).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // A teardown sets the abort flag and the next run clears it again. A loop
+  // still sleeping in the backoff from the previous run wakes into that, with
+  // every array it is about to touch now owned by a different run.
+  it('does not let a dispatch loop that slept through a teardown serve the next run', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    await pool.initializeMappingWorkers(false, undefined, () => {}, 1)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(
+      queueFile('a.dcm'),
+      queueFile('b.dcm'),
+      queueFile('c.dcm'),
+    )
+
+    vi.useFakeTimers()
+    try {
+      let dispatchError: unknown
+      const parked = pool.dispatchMappingJobs().catch((error: unknown) => {
+        dispatchError = error
+      })
+      for (let tick = 0; tick < 5; tick++) {
+        await vi.advanceTimersByTimeAsync(1)
+      }
+
+      pool.terminateAllWorkers()
+
+      rejectAllHeaders = false
+      const secondRunMessages: any[] = []
+      await pool.initializeMappingWorkers(
+        false,
+        undefined,
+        (msg: any) => secondRunMessages.push(msg),
+        1,
+      )
+      pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+      pool.setDirectoryScanFinished(false)
+      pool.filesToProcess.push(queueFile('second-run.dcm'))
+
+      await vi.advanceTimersByTimeAsync(200)
+      await parked
+
+      expect(dispatchError).toBeUndefined()
+      // The second run has dispatched nothing itself, so anything consumed here
+      // was consumed by a loop that belongs to a run which is over.
+      expect(pool.filesToProcess).toHaveLength(1)
+      expect(secondRunMessages).toHaveLength(0)
+      expect(pool.getWorkersActive()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The replacement's own 'initError' can beat its continuation home, and
+  // handleWorkerInitFailure cannot remove it from a pool it has not joined yet.
+  it('keeps a replacement that already failed to initialize out of the pool', async () => {
+    configureMockMappingWorkers(['crash-onerror', 'init-error-immediate'])
+
+    const rejections: Error[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      () => {},
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    await pool.dispatchMappingJobs()
+    await waitFor(() => getMockWorkersCreated().length > 1)
+    await settle()
+
+    const replacement = getMockWorkersCreated()[1]
+    expect(replacement.terminated).toBe(true)
+    // postMessage to a terminated worker is a silent no-op, so a file handed to
+    // this one sits unanswered until the ten-minute stall watchdog.
+    expect(pool.availableMappingWorkers).not.toContain(
+      replacement as unknown as Worker,
+    )
+    expect(pool.availableMappingWorkers).toHaveLength(0)
+    expect(pool.getPendingReplacements()).toBe(0)
+    // Nothing else can report it: handleWorkerInitFailure ran while this
+    // replacement was still counted as pending, so it found the pool not empty.
+    expect(rejections).toHaveLength(1)
+    expect(rejections[0].message).toMatch(
+      /All mapping workers failed to initialize/,
+    )
+  })
+
+  // Both continuations of spawnReplacementWorker mutate module-global pool
+  // state, and the module outlives the run. A replacement resolving after its
+  // own run was torn down must leave the next run's counter alone: one stray
+  // decrement puts its termination condition permanently out of reach.
+  it('abandons a replacement whose run ended before it was created', async () => {
+    configureMockMappingWorkers(['crash-onerror'])
+
+    await pool.initializeMappingWorkers(false, undefined, () => {}, 1)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    pauseWorkerCreation = true
+    await pool.dispatchMappingJobs()
+    await waitFor(() => resumeWorkerCreation !== null)
+    expect(pool.getPendingReplacements()).toBe(1)
+
+    // Run one ends with that replacement still being built.
+    pool.terminateAllWorkers()
+
+    pauseWorkerCreation = false
+    const secondRunMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => secondRunMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    const secondRunWorker = pool.availableMappingWorkers[0]
+
+    // Only now does run one's replacement finish being created.
+    resumeWorkerCreation!()
+    resumeWorkerCreation = null
+    await settle()
+
+    expect(pool.getPendingReplacements()).toBe(0)
+    expect(pool.availableMappingWorkers).toEqual([secondRunWorker])
+    // Abandoned, not leaked: nothing else holds a reference to that thread.
+    expect(getMockWorkersCreated().at(-1)!.terminated).toBe(true)
+
+    // The counter is what proves it: at -1 the termination condition can never
+    // hold and this run could never emit 'done'.
+    pool.setDirectoryScanFinished(true)
+    await pool.dispatchMappingJobs()
+    expect(
+      secondRunMessages.filter((m: any) => m.response === 'done'),
+    ).toHaveLength(1)
+  })
+
+  /**
+   * recoverCrashedWorker returns early for a worker holding no file, so neither
+   * death signal does anything by itself for one that died idle. Without a path
+   * of its own it stays in the pool, is handed the next file, and that file is
+   * stuck until the ten-minute stall watchdog.
+   */
+  async function expectIdleDeathIsReplaced(
+    kill: (worker: MockWorker) => void,
+  ): Promise<void> {
+    configureMockMappingWorkers(['normal'])
+
+    await pool.initializeMappingWorkers(false, undefined, () => {}, 1)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    // Left unfinished so the termination block cannot drain the pool instead.
+    pool.setDirectoryScanFinished(false)
+
+    const dead = getMockWorkersCreated()[0]
+    expect(pool.availableMappingWorkers).toEqual([dead as unknown as Worker])
+
+    kill(dead)
+    await waitFor(
+      () =>
+        pool.availableMappingWorkers.length === 1 &&
+        pool.availableMappingWorkers[0] !== (dead as unknown as Worker),
+    )
+    await settle()
+
+    expect(dead.terminated).toBe(true)
+    expect(pool.getPendingReplacements()).toBe(0)
+
+    // The replacement must also be able to take work.
+    pool.filesToProcess.push(queueFile('a.dcm'))
+    await pool.dispatchMappingJobs()
+    await waitFor(() => pool.getWorkersActive() === 0)
+    expect(pool.filesToProcess).toHaveLength(0)
+  }
+
+  it('replaces a pooled worker that dies while idle (onerror)', async () => {
+    await expectIdleDeathIsReplaced((worker) => {
+      worker.onerror!({ message: 'Simulated idle worker death' })
+    })
+  })
+
+  it('replaces a pooled worker that dies while idle (non-zero exit)', async () => {
+    await expectIdleDeathIsReplaced((worker) => {
+      for (const listener of (worker as any).exitListeners) {
+        listener(1)
+      }
+    })
+  })
+
+  // onerror and 'exit' can both fire for a single crash. The idle path above
+  // must not turn the second of them into a second replacement, nor into a
+  // second accounting of the file the first one already errored.
+  it('spawns one replacement when a busy worker reports its crash twice', async () => {
+    configureMockMappingWorkers(['crash-onerror-and-exit'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    await pool.dispatchMappingJobs()
+    await waitFor(() => progressMessages.length > 0)
+    await settle()
+
+    expect(getMockWorkersCreated()).toHaveLength(2)
+    expect(pool.availableMappingWorkers).toHaveLength(1)
+    expect(pool.getWorkersActive()).toBe(0)
+    expect(progressMessages).toHaveLength(1)
+  })
 })
 
 describe('initializeMappingWorkers', () => {
@@ -804,5 +1174,50 @@ describe('initializeMappingWorkers', () => {
       'workerCount must be an integer between 1 and 64, received 100000',
     )
     expect(getMockWorkersCreated()).toHaveLength(0)
+  })
+
+  // Promise.all rejects on the first failure and drops every worker it had
+  // already built. Nothing else references them, so they can be neither used
+  // nor terminated and hold the Node event loop open.
+  it('terminates the workers it had already built when one cannot be created', async () => {
+    configureMockMappingWorkers(['normal'])
+    workerCreationsBeforeFailure = 4
+
+    await expect(
+      pool.initializeMappingWorkers(false, undefined, () => {}, 8),
+    ).rejects.toThrow('Worker construction failed')
+
+    const created = getMockWorkersCreated()
+    expect(created).toHaveLength(4)
+    expect(created.every((worker) => worker.terminated)).toBe(true)
+    expect(pool.availableMappingWorkers).toHaveLength(0)
+  })
+
+  // getHardwareConcurrency falls back to os.cpus().length, which Node documents
+  // as possibly empty. An unfloored default then builds an empty pool, which can
+  // neither dispatch nor reach the termination condition.
+  it('floors the default worker count when the host reports no CPUs', async () => {
+    configureMockMappingWorkers(['normal'])
+    // hardwareConcurrency is preferred when present, so the os fallback is only
+    // reachable with no navigator at all.
+    vi.stubGlobal('navigator', undefined)
+    vi.doMock('node:os', () => ({ cpus: () => [] }))
+
+    try {
+      const rejections: Error[] = []
+      await pool.initializeMappingWorkers(
+        false,
+        undefined,
+        () => {},
+        undefined,
+        (reason: Error) => rejections.push(reason),
+      )
+
+      expect(pool.availableMappingWorkers).toHaveLength(1)
+      expect(rejections).toHaveLength(0)
+    } finally {
+      vi.doUnmock('node:os')
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -12,6 +12,7 @@ let resumeHeaders: (() => void) | null = null
 let failPausedHeaders: (() => void) | null = null
 let rejectNextHeaders = false
 let rejectAllHeaders = false
+let failWorkerCreation = false
 
 vi.doMock('./httpHeaders', () => ({
   getHttpInputHeaders: vi.fn(async (fileInfo: any) => {
@@ -36,6 +37,9 @@ vi.doMock('./httpHeaders', () => ({
 
 vi.doMock('./worker', () => ({
   createWorker: vi.fn(async () => {
+    if (failWorkerCreation) {
+      throw new Error('Worker construction failed')
+    }
     const mock = new MockWorker(getNextMockBehavior())
     registerMockWorker(mock)
     return mock as unknown as Worker
@@ -82,6 +86,7 @@ describe('dispatchMappingJobs', () => {
     failPausedHeaders = null
     rejectNextHeaders = false
     rejectAllHeaders = false
+    failWorkerCreation = false
     resetMockWorkers()
   })
 
@@ -89,6 +94,10 @@ describe('dispatchMappingJobs', () => {
     // Unblock any pending header awaits so the event loop is clean.
     resumeHeaders?.()
     resumeHeaders = null
+    // availableMappingWorkers is module-global and initializeMappingWorkers
+    // only pushes to it, so a worker one test leaves behind is dispatchable in
+    // the next.
+    pool.terminateAllWorkers()
   })
 
   it('increments workersActive before yielding for header resolution, preventing premature done', async () => {
@@ -265,6 +274,53 @@ describe('dispatchMappingJobs', () => {
     }
 
     expect(rejections).toHaveLength(0)
+  })
+
+  // recoverCrashedWorker ignores a worker holding no file, so without a path
+  // of its own the offender stays in the pool and is handed the next file.
+  it('drops an idle worker that breaks the protocol and replaces it', async () => {
+    configureMockMappingWorkers(['unknown-response-idle'])
+
+    await pool.initializeMappingWorkers(false, undefined, () => {}, 1)
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    // Left unfinished so the termination block cannot drain the pool instead.
+    pool.setDirectoryScanFinished(false)
+
+    const offender = getMockWorkersCreated()[0]
+    await waitFor(() => offender.terminated)
+    await settle()
+
+    expect(pool.availableMappingWorkers).toHaveLength(1)
+    expect(pool.availableMappingWorkers[0]).not.toBe(
+      offender as unknown as Worker,
+    )
+    expect(pool.getPendingReplacements()).toBe(0)
+  })
+
+  // An OOM kill takes the worker and the memory to build another. With no
+  // worker left, dispatch can never run and the queue can never drain, so the
+  // run has to be told rather than left waiting on work that cannot happen.
+  it('fails the run when the last worker cannot be replaced', async () => {
+    configureMockMappingWorkers(['crash-onerror'])
+
+    const rejections: Error[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      () => {},
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'), queueFile('b.dcm'))
+
+    failWorkerCreation = true
+    await pool.dispatchMappingJobs()
+    await waitFor(() => rejections.length > 0)
+
+    expect(rejections[0].message).toMatch(/No mapping workers left/)
+    expect(pool.availableMappingWorkers).toHaveLength(0)
   })
 
   it('does not free a still-busy worker on an unrecognised message', async () => {

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -312,18 +312,30 @@ describe('dispatchMappingJobs', () => {
       (reason: Error) => rejections.push(reason),
     )
     pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
-    pool.setDirectoryScanFinished(true)
+    // Left unfinished: with the scan complete the first good file empties the
+    // queue, which emits 'done' and drains the pool, and every later pair is
+    // then a no-op that proves nothing.
+    pool.setDirectoryScanFinished(false)
 
     // Individually bad files, each followed by a good one: the count resets,
-    // so a run with scattered failures still completes.
-    for (let i = 0; i < 30; i++) {
-      rejectNextHeaders = true
-      pool.filesToProcess.push(queueFile(`bad${i}.dcm`))
-      await pool.dispatchMappingJobs()
-      await settle()
-      pool.filesToProcess.push(queueFile(`good${i}.dcm`))
-      await pool.dispatchMappingJobs()
-      await settle()
+    // so a run with scattered failures still completes. More pairs than
+    // MAX_CONSECUTIVE_DISPATCH_FAILURES, so an unreset count would report.
+    // Fake timers because each failure costs a retry delay.
+    vi.useFakeTimers()
+    try {
+      for (let i = 0; i < 25; i++) {
+        rejectNextHeaders = true
+        pool.filesToProcess.push(queueFile(`bad${i}.dcm`))
+        const failing = pool.dispatchMappingJobs()
+        await vi.advanceTimersByTimeAsync(1_000)
+        await failing
+        pool.filesToProcess.push(queueFile(`good${i}.dcm`))
+        const succeeding = pool.dispatchMappingJobs()
+        await vi.advanceTimersByTimeAsync(1_000)
+        await succeeding
+      }
+    } finally {
+      vi.useRealTimers()
     }
 
     expect(rejections).toHaveLength(0)

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -79,16 +79,23 @@ function queueFile(name: string) {
   return { fileInfo: makeFileInfo(name), scanAnomalies: [] }
 }
 
+/**
+ * The header and worker mocks are driven by file-scoped flags, so every
+ * describe block has to clear them: whatever the previous test set otherwise
+ * leaks into the next one, in a different block or not.
+ */
+function resetMockState(): void {
+  pauseHeaders = false
+  resumeHeaders = null
+  failPausedHeaders = null
+  rejectNextHeaders = false
+  rejectAllHeaders = false
+  failWorkerCreation = false
+  resetMockWorkers()
+}
+
 describe('dispatchMappingJobs', () => {
-  beforeEach(() => {
-    pauseHeaders = false
-    resumeHeaders = null
-    failPausedHeaders = null
-    rejectNextHeaders = false
-    rejectAllHeaders = false
-    failWorkerCreation = false
-    resetMockWorkers()
-  })
+  beforeEach(resetMockState)
 
   afterEach(() => {
     // Unblock any pending header awaits so the event loop is clean.
@@ -554,9 +561,7 @@ describe('dispatchMappingJobs', () => {
 })
 
 describe('initializeMappingWorkers', () => {
-  beforeEach(() => {
-    resetMockWorkers()
-  })
+  beforeEach(resetMockState)
 
   afterEach(() => {
     pool.terminateAllWorkers()
@@ -569,7 +574,22 @@ describe('initializeMappingWorkers', () => {
 
     await expect(
       pool.initializeMappingWorkers(false, undefined, () => {}, 0),
-    ).rejects.toThrow('workerCount must be a positive integer, received 0')
+    ).rejects.toThrow(
+      'workerCount must be an integer between 1 and 64, received 0',
+    )
+    expect(getMockWorkersCreated()).toHaveLength(0)
+  })
+
+  // The default path caps itself at 8; only an explicit count can ask for a
+  // number of threads that exhausts the process before any work is done.
+  it('rejects a workerCount above the ceiling', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    await expect(
+      pool.initializeMappingWorkers(false, undefined, () => {}, 100_000),
+    ).rejects.toThrow(
+      'workerCount must be an integer between 1 and 64, received 100000',
+    )
     expect(getMockWorkersCreated()).toHaveLength(0)
   })
 })

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -11,9 +11,13 @@ let pauseHeaders = false
 let resumeHeaders: (() => void) | null = null
 let failPausedHeaders: (() => void) | null = null
 let rejectNextHeaders = false
+let rejectAllHeaders = false
 
 vi.doMock('./httpHeaders', () => ({
   getHttpInputHeaders: vi.fn(async (fileInfo: any) => {
+    if (rejectAllHeaders) {
+      throw new Error('Header provider unavailable')
+    }
     if (rejectNextHeaders) {
       rejectNextHeaders = false
       throw new Error('Header provider unavailable')
@@ -77,6 +81,7 @@ describe('dispatchMappingJobs', () => {
     resumeHeaders = null
     failPausedHeaders = null
     rejectNextHeaders = false
+    rejectAllHeaders = false
     resetMockWorkers()
   })
 
@@ -198,6 +203,68 @@ describe('dispatchMappingJobs', () => {
     )
     expect(mapped.errors).toEqual([])
     expect(pool.getWorkersActive()).toBe(0)
+  })
+
+  it('fails the run once dispatch has failed for a long enough streak', async () => {
+    // getHttpOutputHeaders runs per file, so one expired token fails every
+    // file in turn. Erroring each of them keeps 'done' reachable but turns a
+    // systemic failure into a successful run full of errors, which reads the
+    // same as a genuine mass failure -- so the pool reports it upward.
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const rejections: Error[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      () => {},
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 40; i++) {
+      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
+    }
+
+    await pool.dispatchMappingJobs()
+    await settle()
+
+    // Once per streak, not once per failed file: the run owner tears the pool
+    // down on the first report, and a success would reset the count.
+    expect(rejections).toHaveLength(1)
+    expect(rejections[0].message).toMatch(
+      /Dispatch failed for 20 consecutive files/,
+    )
+  })
+
+  it('does not report a streak when dispatches succeed in between', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const rejections: Error[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      () => {},
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+
+    // Individually bad files, each followed by a good one: the count resets,
+    // so a run with scattered failures still completes.
+    for (let i = 0; i < 30; i++) {
+      rejectNextHeaders = true
+      pool.filesToProcess.push(queueFile(`bad${i}.dcm`))
+      await pool.dispatchMappingJobs()
+      await settle()
+      pool.filesToProcess.push(queueFile(`good${i}.dcm`))
+      await pool.dispatchMappingJobs()
+      await settle()
+    }
+
+    expect(rejections).toHaveLength(0)
   })
 
   it('does not free a still-busy worker on an unrecognised message', async () => {

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -236,15 +236,55 @@ describe('dispatchMappingJobs', () => {
       pool.filesToProcess.push(queueFile(`f${i}.dcm`))
     }
 
-    await pool.dispatchMappingJobs()
-    await settle()
+    // A failed dispatch returns the worker immediately, so the whole queue
+    // burns in milliseconds. The clock has to move for the streak to count as
+    // sustained rather than as one bad moment.
+    const realNow = Date.now
+    let clock = realNow()
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      clock += 1_000
+      return clock
+    })
+    try {
+      await pool.dispatchMappingJobs()
+      await settle()
+    } finally {
+      Date.now = realNow
+    }
 
     // Once per streak, not once per failed file: the run owner tears the pool
     // down on the first report, and a success would reset the count.
     expect(rejections).toHaveLength(1)
     expect(rejections[0].message).toMatch(
-      /Dispatch failed for 20 consecutive files/,
+      /Dispatch failed for 2\d+ consecutive/,
     )
+  })
+
+  // A token refresh that blips for a second fails a burst of files, all of
+  // which surface individually and are retried by the consumer. Tearing the
+  // whole run down over it costs hours of completed work.
+  it('does not fail the run when a failure burst is over quickly', async () => {
+    rejectAllHeaders = true
+    configureMockMappingWorkers(['normal'])
+
+    const rejections: Error[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      () => {},
+      1,
+      (reason: Error) => rejections.push(reason),
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 40; i++) {
+      pool.filesToProcess.push(queueFile(`f${i}.dcm`))
+    }
+
+    await pool.dispatchMappingJobs()
+    await settle()
+
+    expect(rejections).toEqual([])
   })
 
   it('does not report a streak when dispatches succeed in between', async () => {

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -223,33 +223,34 @@ describe('dispatchMappingJobs', () => {
     configureMockMappingWorkers(['normal'])
 
     const rejections: Error[] = []
+    const progressMessages: any[] = []
     await pool.initializeMappingWorkers(
       false,
       undefined,
-      () => {},
+      (msg: any) => progressMessages.push(msg),
       1,
-      (reason: Error) => rejections.push(reason),
+      // What the run owner does with the report: the teardown is what stops
+      // the loop, so the file count below is the damage a streak really does.
+      (reason: Error) => {
+        rejections.push(reason)
+        pool.terminateAllWorkers()
+      },
     )
     pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
     pool.setDirectoryScanFinished(true)
-    for (let i = 0; i < 40; i++) {
+    for (let i = 0; i < 200; i++) {
       pool.filesToProcess.push(queueFile(`f${i}.dcm`))
     }
 
-    // A failed dispatch returns the worker immediately, so the whole queue
-    // burns in milliseconds. The clock has to move for the streak to count as
-    // sustained rather than as one bad moment.
-    const realNow = Date.now
-    let clock = realNow()
-    vi.spyOn(Date, 'now').mockImplementation(() => {
-      clock += 1_000
-      return clock
-    })
+    // The streak is timed off the same clock as the retry delays, so under
+    // fake timers the delays are what age it into a report.
+    vi.useFakeTimers()
     try {
-      await pool.dispatchMappingJobs()
-      await settle()
+      const dispatchPromise = pool.dispatchMappingJobs()
+      await vi.advanceTimersByTimeAsync(30_000)
+      await dispatchPromise
     } finally {
-      Date.now = realNow
+      vi.useRealTimers()
     }
 
     // Once per streak, not once per failed file: the run owner tears the pool
@@ -258,11 +259,15 @@ describe('dispatchMappingJobs', () => {
     expect(rejections[0].message).toMatch(
       /Dispatch failed for 2\d+ consecutive/,
     )
+    // The point of the retry delay: a 200-file queue loses about twenty files,
+    // not all of them, before the run is failed.
+    expect(progressMessages.length).toBeLessThanOrEqual(25)
+    expect(pool.filesToProcess).toHaveLength(0)
   })
 
-  // A token refresh that blips for a second fails a burst of files, all of
-  // which surface individually and are retried by the consumer. Tearing the
-  // whole run down over it costs hours of completed work.
+  // A token refresh that blips for a few seconds fails a burst of files. The
+  // provider comes back before the streak is old enough to count, and tearing
+  // the whole run down over it would cost hours of completed work.
   it('does not fail the run when a failure burst is over quickly', async () => {
     rejectAllHeaders = true
     configureMockMappingWorkers(['normal'])
@@ -281,8 +286,16 @@ describe('dispatchMappingJobs', () => {
       pool.filesToProcess.push(queueFile(`f${i}.dcm`))
     }
 
-    await pool.dispatchMappingJobs()
-    await settle()
+    vi.useFakeTimers()
+    try {
+      const dispatchPromise = pool.dispatchMappingJobs()
+      await vi.advanceTimersByTimeAsync(4_000)
+      rejectAllHeaders = false
+      await vi.advanceTimersByTimeAsync(4_000)
+      await dispatchPromise
+    } finally {
+      vi.useRealTimers()
+    }
 
     expect(rejections).toEqual([])
   })

--- a/src/mappingWorkerPool.test.ts
+++ b/src/mappingWorkerPool.test.ts
@@ -232,6 +232,39 @@ describe('dispatchMappingJobs', () => {
     expect(pool.availableMappingWorkers).toHaveLength(1)
   })
 
+  it('reports whether the scan has finished on every progress message', async () => {
+    configureMockMappingWorkers(['normal'])
+
+    const progressMessages: any[] = []
+    await pool.initializeMappingWorkers(
+      false,
+      undefined,
+      (msg: any) => progressMessages.push(msg),
+      1,
+    )
+    pool.setMappingWorkerOptions({ curationSpec: () => ({}) } as any)
+    pool.setDirectoryScanFinished(false)
+    pool.filesToProcess.push(queueFile('a.dcm'))
+
+    await pool.dispatchMappingJobs()
+    await waitFor(() => progressMessages.length > 0)
+
+    // Still scanning: totalFiles is a lower bound, which is what a consumer
+    // needs to know before rendering it as a percentage.
+    expect(progressMessages[0].scanComplete).toBe(false)
+
+    pool.setDirectoryScanFinished(true)
+    pool.filesToProcess.push(queueFile('b.dcm'))
+    await pool.dispatchMappingJobs()
+    await waitFor(() => progressMessages.some((m) => m.response === 'done'))
+
+    expect(progressMessages[1].scanComplete).toBe(true)
+    expect(progressMessages.at(-1)).toMatchObject({
+      response: 'done',
+      scanComplete: true,
+    })
+  })
+
   it('leaves the pool clean when the run is aborted during header resolution', async () => {
     pauseHeaders = true
     configureMockMappingWorkers(['normal'])

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -322,8 +322,10 @@ export async function dispatchMappingJobs(): Promise<void> {
       // reason: this await can outlive its file. The stall watchdog may have
       // already recovered the worker, or an abort may have cleared the map --
       // accounting again would double-count the file, return a terminated
-      // worker to the pool, and drive workersActive to -1.
-      if (!workerCurrentFile.has(mappingWorker)) return
+      // worker to the pool, and drive workersActive to -1. Continue rather
+      // than return: the queue drain, the backpressure resume and the
+      // termination check below still belong to this pass.
+      if (!workerCurrentFile.has(mappingWorker)) continue
 
       console.error(
         'Failed to dispatch file to mapping worker:',
@@ -753,6 +755,11 @@ async function createMappingWorker(): Promise<Worker> {
 
     switch (event.data.response) {
       case 'finished':
+        // A reply that arrives after this worker was already recovered (stall
+        // watchdog, or the default: branch below) would count its file twice,
+        // push a terminated worker back into the pool, and drive workersActive
+        // to -1 -- past which the termination condition can never hold.
+        if (!workerCurrentFile.has(mappingWorker)) break
         workerCurrentFile.delete(mappingWorker)
         availableMappingWorkers.push(mappingWorker)
 
@@ -779,6 +786,9 @@ async function createMappingWorker(): Promise<Worker> {
         break
       case 'error': {
         console.error('Error in mapping worker:', event.data.error)
+        // Same guard as 'finished': the file may already have been accounted
+        // by a recovery that ran while this reply was in flight.
+        if (!workerCurrentFile.has(mappingWorker)) break
         failFileAndReturnWorker(
           mappingWorker,
           event.data.fileInfo,

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -84,6 +84,15 @@ let poolInitialized = false
 // can ever drain the queue and 'done' is unreachable.
 let rejectRunCallback: ((reason: Error) => void) | undefined
 
+// Files whose dispatch failed back to back. Header resolution is the usual
+// cause and it runs per file, so one expired token fails every file in turn:
+// unbounded, a 100k-file run turns the whole queue into error results and
+// reports 'done' within seconds, which an operator cannot tell apart from a
+// genuine mass failure. High enough that a handful of individually bad files
+// still just error and the run continues.
+const MAX_CONSECUTIVE_DISPATCH_FAILURES = 20
+let consecutiveDispatchFailures = 0
+
 // Number of replacement workers currently being created asynchronously.
 // The termination condition in dispatchMappingJobs() waits for this to reach 0
 // before finishing, to avoid orphaning in-flight replacements.
@@ -218,6 +227,7 @@ export function terminateAllWorkers(): void {
   filesToProcess.length = 0
   workersActive = 0
   pendingReplacements = 0
+  consecutiveDispatchFailures = 0
   doneEmitted = false
   directoryScanFinished = false
   scanPaused = false
@@ -247,6 +257,7 @@ export async function initializeMappingWorkers(
   poolInitialized = false
   initFailedWorkers.clear()
   lastInitErrorMessage = ''
+  consecutiveDispatchFailures = 0
   rejectRunCallback = rejectCb
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
@@ -317,6 +328,7 @@ export async function dispatchMappingJobs(): Promise<void> {
         hashPartSize,
         serializedMappingOptions: serializeMappingOptions(mappingOptions),
       } satisfies MappingRequest)
+      consecutiveDispatchFailures = 0
     } catch (error) {
       // Same double-recovery guard as recoverCrashedWorker, and for the same
       // reason: this await can outlive its file. The stall watchdog may have
@@ -332,11 +344,21 @@ export async function dispatchMappingJobs(): Promise<void> {
         error,
         `File: ${fileInfo.path}/${fileInfo.name}`,
       )
-      failFileAndReturnWorker(
-        mappingWorker,
-        fileInfo,
-        error instanceof Error ? error.message : String(error),
-      )
+      const message = error instanceof Error ? error.message : String(error)
+      failFileAndReturnWorker(mappingWorker, fileInfo, message)
+
+      // Reported once per streak (a success resets the count). The run owner
+      // decides what to do: its rejection tears the pool down, which empties
+      // the queue and ends this loop. With no callback wired the run drains
+      // into error results as before.
+      consecutiveDispatchFailures += 1
+      if (consecutiveDispatchFailures === MAX_CONSECUTIVE_DISPATCH_FAILURES) {
+        rejectRunCallback?.(
+          new Error(
+            `Dispatch failed for ${MAX_CONSECUTIVE_DISPATCH_FAILURES} consecutive files, last: ${message}`,
+          ),
+        )
+      }
     }
   }
 

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -60,8 +60,13 @@ let filesMapped = 0
 // the failing file and include it in the error report.
 const workerCurrentFile = new Map<Worker, TFileInfo>()
 
-// Track the last time any worker reported progress, used by the stall watchdog.
-let lastWorkerProgressTime = 0
+// Track the last time a mapping worker, and separately the scanner, reported
+// progress. Used by the stall watchdog. Kept apart because the scanner's file
+// counter runs even while it is paused for backpressure (see ScanController
+// in scanCore.ts), so scan activity must never be treated as evidence that
+// the mapping pump itself is still alive.
+let lastMappingProgressTime = 0
+let lastScanProgressTime = 0
 
 // Number of replacement workers currently being created asynchronously.
 // The termination condition in dispatchMappingJobs() waits for this to reach 0
@@ -89,14 +94,14 @@ let currentUploader: TCustomUploader | undefined
 let currentSignal: AbortSignal | undefined
 
 // Shared state accessed by both scan worker (in index.ts) and dispatch (here).
-// Exported so index.ts can push items and set the scan-finished flag.
+// Exported so index.ts can push items and read the queue length.
 export let filesToProcess: {
   fileInfo: TFileInfo
   scanAnomalies: string[]
   previousFileInfo?: { size?: number; mtime?: string; preMappedHash?: string }
 }[] = []
 
-export let directoryScanFinished = false
+let directoryScanFinished = false
 
 export function setDirectoryScanFinished(value: boolean): void {
   directoryScanFinished = value
@@ -197,6 +202,7 @@ export function terminateAllWorkers(): void {
   filesToProcess.length = 0
   workersActive = 0
   pendingReplacements = 0
+  doneEmitted = false
   directoryScanFinished = false
   scanPaused = false
   scanResumeCallback = null
@@ -227,7 +233,8 @@ export async function initializeMappingWorkers(
   doneEmitted = false
   aborted = false
   workerCurrentFile.clear()
-  lastWorkerProgressTime = Date.now()
+  lastMappingProgressTime = Date.now()
+  lastScanProgressTime = Date.now()
   currentFileInfoIndex = fileInfoIndex
   currentUploader = undefined
   filesToProcess = []
@@ -596,10 +603,13 @@ async function createMappingWorker(): Promise<Worker> {
     // Ignore messages from workers after abort — the pool is torn down.
     if (aborted) return
 
-    // Any message from a worker means progress is being made. Recorded before
-    // the lookup/upload branches below so that a consumer upload slower than
-    // the stall timeout is not mistaken for a hung worker.
-    lastWorkerProgressTime = Date.now()
+    // Any message from a worker means mapping progress is being made.
+    // Recorded before the lookup/upload branches below so a consumer upload
+    // that generates message traffic isn't mistaken for a hung worker -- a
+    // single upload that stays completely silent for the full 10 minutes
+    // still trips the watchdog, since there's no per-upload progress signal
+    // to hook here.
+    lastMappingProgressTime = Date.now()
 
     // Handle lookup requests from the worker. The worker sends these when
     // curateOne needs to check if a mapped file was already uploaded
@@ -725,10 +735,20 @@ export function getWorkersActive(): number {
 }
 
 /**
- * Get the last time a worker reported progress. Used by the stall watchdog.
+ * Get the last time a mapping worker reported progress. Used by the stall
+ * watchdog while mapping work is outstanding.
  */
-export function getLastWorkerProgressTime(): number {
-  return lastWorkerProgressTime
+export function getLastMappingProgressTime(): number {
+  return lastMappingProgressTime
+}
+
+/**
+ * Get the last time the scanner reported progress, including its
+ * backpressure-immune file counter. Used by the stall watchdog only once
+ * there is no mapping work outstanding and it is waiting on the scan itself.
+ */
+export function getLastScanProgressTime(): number {
+  return lastScanProgressTime
 }
 
 /**
@@ -741,14 +761,6 @@ export function getPendingReplacements(): number {
 }
 
 /**
- * Number of files still queued for dispatch. Used by the stall watchdog: a
- * wedged pump leaves work queued with no worker active to drain it.
- */
-export function getQueueLength(): number {
-  return filesToProcess.length
-}
-
-/**
  * Whether the directory scan has finished. Used by the stall watchdog to tell
  * an idle-but-unfinished run from a completed one.
  */
@@ -757,10 +769,20 @@ export function isDirectoryScanFinished(): boolean {
 }
 
 /**
- * Restart the stall watchdog's progress baseline after it has taken recovery
- * action, so a run that stays stuck reports once per timeout rather than once
- * per watchdog tick.
+ * Refresh the scan progress baseline. Called on every scan-worker message,
+ * including the backpressure-immune file counter -- so this must only ever
+ * stand as evidence the scanner is alive, never the mapping pump.
  */
-export function resetWorkerProgressTime(): void {
-  lastWorkerProgressTime = Date.now()
+export function resetScanProgressTime(): void {
+  lastScanProgressTime = Date.now()
+}
+
+/**
+ * Restart both stall watchdog baselines after it has taken recovery action,
+ * so a run that stays stuck reports once per timeout rather than once per
+ * watchdog tick.
+ */
+export function resetProgressTimestamps(): void {
+  lastMappingProgressTime = Date.now()
+  lastScanProgressTime = Date.now()
 }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -389,6 +389,9 @@ export async function dispatchMappingJobs(): Promise<void> {
       mapResultsList: mapResultsList,
       processedFiles: filesMapped,
       totalFiles: filesMapped,
+      // Always true here -- the termination condition requires it -- but set
+      // explicitly so a consumer never reads `undefined` on the final message.
+      scanComplete: true,
     })
   }
 }
@@ -449,6 +452,7 @@ function failFileAndReturnWorker(
     totalFiles:
       totalDiscoveredFiles ??
       filesToProcess.length + filesMapped + workersActive,
+    scanComplete: directoryScanFinished,
   })
 }
 
@@ -519,6 +523,7 @@ function recoverCrashedWorker(
     totalFiles:
       totalDiscoveredFiles ??
       filesToProcess.length + filesMapped + workersActive,
+    scanComplete: directoryScanFinished,
   })
 
   // Counted before dispatching: with an empty queue dispatchMappingJobs() runs
@@ -668,6 +673,7 @@ async function createMappingWorker(): Promise<Worker> {
           totalFiles:
             totalDiscoveredFiles ??
             filesToProcess.length + filesMapped + workersActive,
+          scanComplete: directoryScanFinished,
         })
 
         dispatchMappingJobs()

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -12,6 +12,7 @@ import type {
   UploadResult,
 } from './applyMappingsWorker'
 import { safeSerializeError } from './applyMappingsWorker'
+import { delay } from './delay'
 import { phiSafeToken } from './hash'
 import { getHttpInputHeaders, getHttpOutputHeaders } from './httpHeaders'
 import { serializeMappingOptions } from './serializeMappingOptions'
@@ -95,23 +96,42 @@ const MAX_WORKER_COUNT = 64
 // reports 'done' within seconds, which an operator cannot tell apart from a
 // genuine mass failure. High enough that a handful of individually bad files
 // still just error and the run continues.
+//
+// Under a live provider outage the backoff below paces failures faster than
+// this count, so the duration gate is what decides. This gate decides when
+// failures arrive more slowly than the backoff -- a queue the scanner is only
+// trickling into -- where two failures eleven seconds apart must not be read
+// as a systemic one.
 const MAX_CONSECUTIVE_DISPATCH_FAILURES = 20
 
 // ...and the streak has to have lasted this long, so that on the count alone a
-// token refresh that blips for a second cannot tear a run down. Files failed
-// during the window surface as plain error results, indistinguishable from a
-// genuinely bad file, so the retry delay below is what bounds the loss.
+// token refresh that blips for a second cannot tear a run down.
 const MIN_DISPATCH_FAILURE_STREAK_MS = 10_000
 
-// How long to wait after a failed dispatch while a streak is live. A failed
-// dispatch returns its worker to the pool immediately, so without this the
-// loop burns the whole queue before the streak is old enough to report. At
-// this delay both gates above are reached together, which bounds the damage
-// at roughly MAX_CONSECUTIVE_DISPATCH_FAILURES files per streak.
-const DISPATCH_FAILURE_RETRY_DELAY_MS = 500
+// Backoff between dispatch attempts while a streak is live, doubling from the
+// SECOND consecutive failure: an isolated bad file waits not at all, which is
+// what keeps MAX_CONSECUTIVE_DISPATCH_FAILURES worth of scattered failures
+// cheap. Failed files surface as plain error results, indistinguishable from a
+// genuinely bad file, so this backoff is the only thing bounding the loss --
+// it has to reach MIN_DISPATCH_FAILURE_STREAK_MS in roughly
+// MAX_CONSECUTIVE_DISPATCH_FAILURES files. At 50ms doubling to a 500ms ceiling
+// the twentieth failure lands at ~8.3s, so a streak reports at ~25 files.
+const DISPATCH_BACKOFF_BASE_MS = 50
+const DISPATCH_BACKOFF_MAX_MS = 500
 let consecutiveDispatchFailures = 0
 let dispatchFailureStreakStart = 0
 let dispatchFailureReported = false
+
+// When the next dispatch attempt may proceed, and whether a loop is already
+// making it. Both are checked at the top of the dispatch loop rather than
+// after a failure, because a failed dispatch returns its worker to the pool
+// immediately: a loop sleeping after the release holds nothing, so every other
+// dispatchMappingJobs() call -- one per scan-worker message -- would pop that
+// worker and fail another file at full speed. Deferring every caller bounds a
+// streak by time; admitting only one of them keeps that bound at ~25 files
+// rather than ~25 per worker.
+let dispatchBackoffUntil = 0
+let dispatchProbeActive = false
 
 // Number of replacement workers currently being created asynchronously.
 // The termination condition in dispatchMappingJobs() waits for this to reach 0
@@ -247,7 +267,7 @@ export function terminateAllWorkers(): void {
   filesToProcess.length = 0
   workersActive = 0
   pendingReplacements = 0
-  consecutiveDispatchFailures = 0
+  resetDispatchFailureState()
   doneEmitted = false
   directoryScanFinished = false
   scanPaused = false
@@ -277,9 +297,7 @@ export async function initializeMappingWorkers(
   poolInitialized = false
   initFailedWorkers.clear()
   lastInitErrorMessage = ''
-  consecutiveDispatchFailures = 0
-  dispatchFailureStreakStart = 0
-  dispatchFailureReported = false
+  resetDispatchFailureState()
   rejectRunCallback = rejectCb
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
@@ -342,6 +360,29 @@ export async function dispatchMappingJobs(): Promise<void> {
   if (aborted) return
 
   while (filesToProcess.length > 0 && availableMappingWorkers.length > 0) {
+    // A streak is live, so pace the retries -- and let only one loop do the
+    // pacing. Both checks sit above the pops, so a caller that defers leaves
+    // the queue and the pool exactly as it found them.
+    //
+    // Tracked per iteration rather than globally: a loop already past this gate
+    // when the streak began holds nothing, and must not release the probe some
+    // other loop is holding.
+    let holdsDispatchProbe = false
+    if (consecutiveDispatchFailures > 0) {
+      // break rather than return: the backpressure resume and the termination
+      // check below still belong to this pass.
+      if (dispatchProbeActive) break
+      dispatchProbeActive = true
+      holdsDispatchProbe = true
+      const waitMs = dispatchBackoffUntil - Date.now()
+      if (waitMs > 0) await delay(waitMs)
+      // The run can be torn down during that wait.
+      if (aborted) {
+        dispatchProbeActive = false
+        return
+      }
+    }
+
     const { fileInfo, previousFileInfo } = filesToProcess.pop()!
     const mappingWorker = availableMappingWorkers.pop()!
 
@@ -384,8 +425,7 @@ export async function dispatchMappingJobs(): Promise<void> {
         hashPartSize,
         serializedMappingOptions: serializeMappingOptions(mappingOptions),
       } satisfies MappingRequest)
-      consecutiveDispatchFailures = 0
-      dispatchFailureReported = false
+      resetDispatchFailureState()
     } catch (error) {
       // Same double-recovery guard as recoverCrashedWorker, and for the same
       // reason: this await can outlive its file. The stall watchdog may have
@@ -407,11 +447,15 @@ export async function dispatchMappingJobs(): Promise<void> {
       // Reported once per streak (a success resets it). The run owner decides
       // what to do: its rejection tears the pool down, which empties the queue
       // and ends this loop. With no callback wired the run drains into error
-      // results as before.
+      // results as before -- which is why the backoff below is not conditional
+      // on having reported: nothing guarantees a report stops anything.
       if (consecutiveDispatchFailures === 0) {
         dispatchFailureStreakStart = Date.now()
       }
       consecutiveDispatchFailures += 1
+      dispatchBackoffUntil =
+        Date.now() + dispatchBackoffMs(consecutiveDispatchFailures)
+
       const streakDuration = Date.now() - dispatchFailureStreakStart
       if (
         !dispatchFailureReported &&
@@ -425,16 +469,12 @@ export async function dispatchMappingJobs(): Promise<void> {
           ),
         )
       }
-
-      // Reporting tears the pool down, which clears the queue and ends this
-      // loop, so only an unreported streak is worth slowing down.
-      if (!dispatchFailureReported) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, DISPATCH_FAILURE_RETRY_DELAY_MS),
-        )
-        // The run can be torn down during that wait.
-        if (aborted) return
-      }
+    } finally {
+      // Whether the attempt succeeded, failed, or bailed out on a worker
+      // something else had already recovered, the next retry is somebody's to
+      // make. Held across the attempt itself, not just the wait, so a pool of
+      // N workers cannot pile N failures into one backoff window.
+      if (holdsDispatchProbe) dispatchProbeActive = false
     }
   }
 
@@ -548,6 +588,36 @@ function safeProgress(message: TProgressMessage): void {
   } catch (error) {
     console.error('Progress callback threw; continuing:', error)
   }
+}
+
+/**
+ * How long to wait before the next dispatch attempt, given the streak so far.
+ *
+ * Zero for the first failure: a run with scattered bad files must not pay for
+ * the streak machinery, which is the whole reason
+ * MAX_CONSECUTIVE_DISPATCH_FAILURES is set as high as it is.
+ */
+function dispatchBackoffMs(consecutiveFailures: number): number {
+  if (consecutiveFailures < 2) return 0
+  return Math.min(
+    DISPATCH_BACKOFF_BASE_MS * 2 ** (consecutiveFailures - 2),
+    DISPATCH_BACKOFF_MAX_MS,
+  )
+}
+
+/**
+ * Clear every piece of dispatch-failure state together.
+ *
+ * Split out because the two callers had drifted: leaving `dispatchFailureReported`
+ * set behind a zeroed count means 'never back off again, and start the next
+ * streak from a stale streak start'.
+ */
+function resetDispatchFailureState(): void {
+  consecutiveDispatchFailures = 0
+  dispatchFailureStreakStart = 0
+  dispatchFailureReported = false
+  dispatchBackoffUntil = 0
+  dispatchProbeActive = false
 }
 
 /**

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -69,9 +69,10 @@ const workerCurrentFile = new Map<Worker, TFileInfo>()
 let lastMappingProgressTime = 0
 let lastScanProgressTime = 0
 
-// Workers that reported 'initError'. Tracked because the failure can land
-// while initializeMappingWorkers is still assembling the pool, and those
-// workers must not be pushed as dispatchable afterwards.
+// Workers that reported 'initError' before joining the pool. The failure can
+// beat either push -- initializeMappingWorkers' or spawnReplacementWorker's --
+// and neither may make a terminated worker dispatchable. Each entry is deleted
+// by the push that reads it, so no dead Worker handle is retained.
 const initFailedWorkers = new Set<Worker>()
 let lastInitErrorMessage = ''
 
@@ -147,6 +148,13 @@ let doneEmitted = false
 // crash recovery, and worker message handlers against acting on stale state
 // after teardown.
 let aborted = false
+
+// Identifies the run the pool currently belongs to. Bumped by every teardown
+// and every fresh initialization, and captured by spawnReplacementWorker so its
+// continuations can tell whether their run is still current. Pool state is
+// module-global: without this, a replacement resolving after its run ended
+// decrements the next run's pendingReplacements, which then never reaches zero.
+let currentRunId = 0
 
 // Stored fileInfoIndex from initializeMappingWorkers, used for lookup
 // responses when workers query for previousMappedFileInfo.
@@ -247,6 +255,7 @@ export function markScanPaused(): void {
  */
 export function terminateAllWorkers(): void {
   aborted = true
+  currentRunId += 1
 
   // Terminate idle workers
   while (availableMappingWorkers.length) {
@@ -268,6 +277,7 @@ export function terminateAllWorkers(): void {
   workersActive = 0
   pendingReplacements = 0
   resetDispatchFailureState()
+  dispatchProbeActive = false
   doneEmitted = false
   directoryScanFinished = false
   scanPaused = false
@@ -298,6 +308,8 @@ export async function initializeMappingWorkers(
   initFailedWorkers.clear()
   lastInitErrorMessage = ''
   resetDispatchFailureState()
+  dispatchProbeActive = false
+  currentRunId += 1
   rejectRunCallback = rejectCb
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
@@ -336,15 +348,38 @@ export async function initializeMappingWorkers(
   }
 
   const effectiveWorkerCount =
-    workerCount ?? Math.min(await getHardwareConcurrency(), 8)
-  const workers = await Promise.all(
+    workerCount ?? Math.max(1, Math.min(await getHardwareConcurrency(), 8))
+
+  const results = await Promise.allSettled(
     Array.from({ length: effectiveWorkerCount }, () => createMappingWorker()),
   )
+  const workers: Worker[] = []
+  let creationFailure: { reason: unknown } | undefined
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      workers.push(result.value)
+    } else if (!creationFailure) {
+      creationFailure = { reason: result.reason }
+    }
+  }
+  if (creationFailure) {
+    for (const worker of workers) {
+      try {
+        worker.terminate()
+      } catch {
+        // Worker may already be terminated
+      }
+    }
+    throw creationFailure.reason
+  }
+
   // A worker whose 'initError' already arrived was terminated by
   // handleWorkerInitFailure before this push and must not become dispatchable.
-  availableMappingWorkers.push(
-    ...workers.filter((worker) => !initFailedWorkers.has(worker)),
-  )
+  // The entry is deleted as it is read: this push is its only consumer.
+  for (const worker of workers) {
+    if (initFailedWorkers.delete(worker)) continue
+    availableMappingWorkers.push(worker)
+  }
   poolInitialized = true
   rejectIfNoWorkersLeft(
     `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
@@ -359,6 +394,8 @@ export async function initializeMappingWorkers(
 export async function dispatchMappingJobs(): Promise<void> {
   if (aborted) return
 
+  const runId = currentRunId
+
   while (filesToProcess.length > 0 && availableMappingWorkers.length > 0) {
     // A streak is live, so pace the retries -- and let only one loop do the
     // pacing. Both checks sit above the pops, so a caller that defers leaves
@@ -368,113 +405,132 @@ export async function dispatchMappingJobs(): Promise<void> {
     // when the streak began holds nothing, and must not release the probe some
     // other loop is holding.
     let holdsDispatchProbe = false
-    if (consecutiveDispatchFailures > 0) {
-      // break rather than return: the backpressure resume and the termination
-      // check below still belong to this pass.
-      if (dispatchProbeActive) break
-      dispatchProbeActive = true
-      holdsDispatchProbe = true
-      const waitMs = dispatchBackoffUntil - Date.now()
-      if (waitMs > 0) await delay(waitMs)
-      // The run can be torn down during that wait.
-      if (aborted) {
-        dispatchProbeActive = false
-        return
-      }
-    }
-
-    const { fileInfo, previousFileInfo } = filesToProcess.pop()!
-    const mappingWorker = availableMappingWorkers.pop()!
-
-    // Track which file this worker is processing so we can identify it
-    // if the worker crashes.
-    workerCurrentFile.set(mappingWorker, fileInfo)
-
-    // Increment before the awaits below: a concurrent dispatchMappingJobs() call
-    // triggered by a finishing worker must see a non-zero count or it will emit
-    // 'done' prematurely while headers are still being resolved.
-    workersActive += 1
-
-    const { outputTarget, hashMethod, hashPartSize, ...mappingOptions } =
-      // Not partial anymore.
-      mappingWorkerOptions as TMappingWorkerOptions
-
-    // A header provider that rejects (expired credentials, a network failure)
-    // would otherwise leave this file popped and this worker slot consumed for
-    // the rest of the run, so the termination condition could never be met.
     try {
-      // Independent providers, and both are per-file round trips on the
-      // dispatch hot path, so they are resolved together rather than in turn.
-      const [inputFileInfo, resolvedOutputTarget] = await Promise.all([
-        getHttpInputHeaders(fileInfo),
-        getHttpOutputHeaders(outputTarget),
-      ])
-
-      // Same double-recovery guard as the failure branch below, and for the
-      // same reason: those awaits can outlive their file. If the stall watchdog
-      // or an abort has already recovered this worker, posting to it now leaves
-      // workersActive incremented for a reply that can never arrive.
-      if (!workerCurrentFile.has(mappingWorker)) continue
-
-      mappingWorker.postMessage({
-        request: 'apply',
-        fileInfo: inputFileInfo,
-        outputTarget: resolvedOutputTarget,
-        previousFileInfo,
-        hashMethod,
-        hashPartSize,
-        serializedMappingOptions: serializeMappingOptions(mappingOptions),
-      } satisfies MappingRequest)
-      resetDispatchFailureState()
-    } catch (error) {
-      // Same double-recovery guard as recoverCrashedWorker, and for the same
-      // reason: this await can outlive its file. The stall watchdog may have
-      // already recovered the worker, or an abort may have cleared the map --
-      // accounting again would double-count the file, return a terminated
-      // worker to the pool, and drive workersActive to -1. Continue rather
-      // than return: the queue drain, the backpressure resume and the
-      // termination check below still belong to this pass.
-      if (!workerCurrentFile.has(mappingWorker)) continue
-
-      console.error(
-        'Failed to dispatch file to mapping worker:',
-        error,
-        `File: ${fileInfo.path}/${fileInfo.name}`,
-      )
-      const message = error instanceof Error ? error.message : String(error)
-      failFileAndReturnWorker(mappingWorker, fileInfo, message)
-
-      // Reported once per streak (a success resets it). The run owner decides
-      // what to do: its rejection tears the pool down, which empties the queue
-      // and ends this loop. With no callback wired the run drains into error
-      // results as before -- which is why the backoff below is not conditional
-      // on having reported: nothing guarantees a report stops anything.
-      if (consecutiveDispatchFailures === 0) {
-        dispatchFailureStreakStart = Date.now()
+      if (consecutiveDispatchFailures > 0) {
+        // break rather than return: the backpressure resume and the termination
+        // check below still belong to this pass.
+        if (dispatchProbeActive) break
+        dispatchProbeActive = true
+        holdsDispatchProbe = true
+        const waitMs = dispatchBackoffUntil - Date.now()
+        if (waitMs > 0) await delay(waitMs)
+        // The run can be torn down during the wait and another started in its
+        // place, which resets `aborted` to false. The run check is what catches
+        // that.
+        if (aborted || runId !== currentRunId) return
+        // Both loop invariants can go stale across the wait: another loop past
+        // this gate can drain the queue, and an idle 'initError' removes a
+        // worker without spawning a replacement. The while condition last held
+        // before the sleep, so the pops below must be re-earned.
+        if (
+          filesToProcess.length === 0 ||
+          availableMappingWorkers.length === 0
+        ) {
+          break
+        }
       }
-      consecutiveDispatchFailures += 1
-      dispatchBackoffUntil =
-        Date.now() + dispatchBackoffMs(consecutiveDispatchFailures)
 
-      const streakDuration = Date.now() - dispatchFailureStreakStart
-      if (
-        !dispatchFailureReported &&
-        consecutiveDispatchFailures >= MAX_CONSECUTIVE_DISPATCH_FAILURES &&
-        streakDuration >= MIN_DISPATCH_FAILURE_STREAK_MS
-      ) {
-        dispatchFailureReported = true
-        rejectRunCallback?.(
-          new Error(
-            `Dispatch failed for ${consecutiveDispatchFailures} consecutive files over ${Math.round(streakDuration / 1000)}s, last: ${message}`,
-          ),
+      const { fileInfo, previousFileInfo } = filesToProcess.pop()!
+      const mappingWorker = availableMappingWorkers.pop()!
+
+      // Track which file this worker is processing so we can identify it
+      // if the worker crashes.
+      workerCurrentFile.set(mappingWorker, fileInfo)
+
+      // Increment before the awaits below: a concurrent dispatchMappingJobs()
+      // call triggered by a finishing worker must see a non-zero count or it
+      // will emit 'done' prematurely while headers are still being resolved.
+      workersActive += 1
+
+      const { outputTarget, hashMethod, hashPartSize, ...mappingOptions } =
+        // Not partial anymore.
+        mappingWorkerOptions as TMappingWorkerOptions
+
+      // A header provider that rejects (expired credentials, a network failure)
+      // would otherwise leave this file popped and this worker slot consumed
+      // for the rest of the run, so the termination condition could never be
+      // met.
+      try {
+        // Independent providers, and both are per-file round trips on the
+        // dispatch hot path, so they are resolved together rather than in turn.
+        const [inputFileInfo, resolvedOutputTarget] = await Promise.all([
+          getHttpInputHeaders(fileInfo),
+          getHttpOutputHeaders(outputTarget),
+        ])
+
+        // Same double-recovery guard as the failure branch below, and for the
+        // same reason: those awaits can outlive their file. If the stall
+        // watchdog or an abort has already recovered this worker, posting to it
+        // now leaves workersActive incremented for a reply that can never
+        // arrive.
+        if (!workerCurrentFile.has(mappingWorker)) continue
+
+        mappingWorker.postMessage({
+          request: 'apply',
+          fileInfo: inputFileInfo,
+          outputTarget: resolvedOutputTarget,
+          previousFileInfo,
+          hashMethod,
+          hashPartSize,
+          serializedMappingOptions: serializeMappingOptions(mappingOptions),
+        } satisfies MappingRequest)
+        resetDispatchFailureState()
+      } catch (error) {
+        // Same double-recovery guard as recoverCrashedWorker, and for the same
+        // reason: this await can outlive its file. The stall watchdog may have
+        // already recovered the worker, or an abort may have cleared the map --
+        // accounting again would double-count the file, return a terminated
+        // worker to the pool, and drive workersActive to -1. Continue rather
+        // than return: the queue drain, the backpressure resume and the
+        // termination check below still belong to this pass.
+        if (!workerCurrentFile.has(mappingWorker)) continue
+
+        console.error(
+          'Failed to dispatch file to mapping worker:',
+          error,
+          `File: ${fileInfo.path}/${fileInfo.name}`,
         )
+        const message = error instanceof Error ? error.message : String(error)
+        failFileAndReturnWorker(mappingWorker, fileInfo, message)
+
+        // Reported once per streak (a success resets it). The run owner decides
+        // what to do: its rejection tears the pool down, which empties the
+        // queue and ends this loop. With no callback wired the run drains into
+        // error results as before -- which is why the backoff below is not
+        // conditional on having reported: nothing guarantees a report stops
+        // anything.
+        if (consecutiveDispatchFailures === 0) {
+          dispatchFailureStreakStart = Date.now()
+        }
+        consecutiveDispatchFailures += 1
+        dispatchBackoffUntil =
+          Date.now() + dispatchBackoffMs(consecutiveDispatchFailures)
+
+        const streakDuration = Date.now() - dispatchFailureStreakStart
+        if (
+          !dispatchFailureReported &&
+          consecutiveDispatchFailures >= MAX_CONSECUTIVE_DISPATCH_FAILURES &&
+          streakDuration >= MIN_DISPATCH_FAILURE_STREAK_MS
+        ) {
+          dispatchFailureReported = true
+          rejectRunCallback?.(
+            new Error(
+              `Dispatch failed for ${consecutiveDispatchFailures} consecutive files over ${Math.round(streakDuration / 1000)}s, last: ${message}`,
+            ),
+          )
+        }
       }
     } finally {
-      // Whether the attempt succeeded, failed, or bailed out on a worker
-      // something else had already recovered, the next retry is somebody's to
-      // make. Held across the attempt itself, not just the wait, so a pool of
-      // N workers cannot pile N failures into one backoff window.
-      if (holdsDispatchProbe) dispatchProbeActive = false
+      // Released on every exit from an iteration that acquired it: success,
+      // failure, a worker something else recovered, or a bail-out before the
+      // pops. Held across the whole attempt rather than just the wait, so a pool
+      // of N workers cannot pile N failures into one backoff window.
+      //
+      // Ownership is checked, not assumed: a loop that slept through a teardown
+      // would otherwise release a probe the next run's loop has since acquired.
+      if (holdsDispatchProbe && runId === currentRunId) {
+        dispatchProbeActive = false
+      }
     }
   }
 
@@ -611,13 +667,16 @@ function dispatchBackoffMs(consecutiveFailures: number): number {
  * Split out because the two callers had drifted: leaving `dispatchFailureReported`
  * set behind a zeroed count means 'never back off again, and start the next
  * streak from a stale streak start'.
+ *
+ * Leaves `dispatchProbeActive` alone: this also runs from the dispatch success
+ * path, which may be a loop that never acquired the probe. Ownership stays with
+ * the acquiring iteration; the two teardown callers clear it themselves.
  */
 function resetDispatchFailureState(): void {
   consecutiveDispatchFailures = 0
   dispatchFailureStreakStart = 0
   dispatchFailureReported = false
   dispatchBackoffUntil = 0
-  dispatchProbeActive = false
 }
 
 /**
@@ -746,9 +805,9 @@ function recoverCrashedWorker(
 }
 
 /**
- * Drop an idle worker that broke the message protocol and replace it. It holds
- * no file, so there is nothing to account -- but leaving it in the pool means
- * handing it the next one.
+ * Drop an idle worker that can no longer serve a file -- it broke the message
+ * protocol, or it died holding nothing -- and replace it. There is no in-flight
+ * file to account, but leaving it in the pool means handing it the next one.
  */
 function retireIdleWorker(mappingWorker: Worker): void {
   if (aborted) return
@@ -777,14 +836,26 @@ function retireIdleWorker(mappingWorker: Worker): void {
  */
 function spawnReplacementWorker(): void {
   pendingReplacements += 1
+  const runId = currentRunId
 
   void createMappingWorker()
     .then((worker) => {
-      pendingReplacements -= 1
-      // If processing was aborted while the replacement was being created,
-      // terminate it immediately instead of adding it to the pool.
-      if (aborted) {
+      // If the run that asked for this replacement is over, the continuation
+      // must touch no shared state.
+      if (runId !== currentRunId || aborted) {
         worker.terminate()
+        return
+      }
+      pendingReplacements -= 1
+      // The replacement's own 'initError' can land before this continuation
+      // runs, when handleWorkerInitFailure has no pool entry to remove.
+      if (initFailedWorkers.delete(worker)) {
+        dispatchMappingJobs()
+        // Nothing else will report it: handleWorkerInitFailure ran while this
+        // replacement was still counted as pending, so it saw a non-empty pool.
+        rejectIfNoWorkersLeft(
+          `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
+        )
         return
       }
       availableMappingWorkers.push(worker)
@@ -792,6 +863,8 @@ function spawnReplacementWorker(): void {
     })
     .catch((error: unknown) => {
       console.error('Failed to create replacement worker:', error)
+      // A failure from run 1 must not tear down a healthy run 2.
+      if (runId !== currentRunId || aborted) return
       pendingReplacements -= 1
       dispatchMappingJobs()
       // Whatever killed the worker can equally stop a new one being built (an
@@ -838,7 +911,6 @@ function handleWorkerInitFailure(mappingWorker: Worker, error: string): void {
 
   console.error('Mapping worker failed to initialize:', error)
   lastInitErrorMessage = error
-  initFailedWorkers.add(mappingWorker)
 
   // A file was dispatched before the failure surfaced: recover it like any
   // crash. A pool-wide breakage makes the replacement fail the same way, but
@@ -855,7 +927,14 @@ function handleWorkerInitFailure(mappingWorker: Worker, error: string): void {
   // replacement -- an environment that cannot initialize a worker will not
   // do better on retry.
   const index = availableMappingWorkers.indexOf(mappingWorker)
-  if (index !== -1) availableMappingWorkers.splice(index, 1)
+  if (index !== -1) {
+    availableMappingWorkers.splice(index, 1)
+  } else {
+    // Not in the pool: the failure beat one of the two pushes, neither of which
+    // is reachable from here. Recorded so that push drops it instead. Only this
+    // branch records, so every entry has a consumer.
+    initFailedWorkers.add(mappingWorker)
+  }
   try {
     mappingWorker.terminate()
   } catch {
@@ -886,7 +965,19 @@ async function createMappingWorker(): Promise<Worker> {
       'message' in event
         ? (event as { message: string }).message
         : `Worker error: ${String(event)}`
-    recoverCrashedWorker(mappingWorker, errorMessage)
+    if (workerCurrentFile.has(mappingWorker)) {
+      recoverCrashedWorker(mappingWorker, errorMessage)
+      return
+    }
+    // A worker that died while idle holds no file, so recoverCrashedWorker would
+    // return having done nothing and leave a dead thread pooled for the next
+    // dispatch. Pool membership also distinguishes this from the second event of
+    // one crash: onerror and 'exit' can both fire, and only the first finds the
+    // worker still dispatchable.
+    if (availableMappingWorkers.includes(mappingWorker)) {
+      console.error(`Mapping worker died while idle: ${errorMessage}`)
+      retireIdleWorker(mappingWorker)
+    }
   }
 
   // Handle unexpected worker exit (OOM, segfault, unhandled rejection that
@@ -895,11 +986,21 @@ async function createMappingWorker(): Promise<Worker> {
     ;(mappingWorker as unknown as NodeWorkerLike).on('exit', (code: number) => {
       // Normal exit (code 0) after terminate() is expected -- ignore it.
       // Non-zero exit means the worker crashed.
-      if (code !== 0 && workerCurrentFile.has(mappingWorker)) {
+      if (code === 0) return
+      if (workerCurrentFile.has(mappingWorker)) {
         recoverCrashedWorker(
           mappingWorker,
           `Worker exited unexpectedly with code ${code}`,
         )
+        return
+      }
+      // Idle death, as in onerror above. The pool membership check is what
+      // stops this firing a second time for a crash onerror already recovered:
+      // every intentional terminate() removes the worker from the pool first, so
+      // the non-zero exit it produces is correctly ignored here.
+      if (availableMappingWorkers.includes(mappingWorker)) {
+        console.error(`Mapping worker exited while idle with code ${code}`)
+        retireIdleWorker(mappingWorker)
       }
     })
   }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -91,7 +91,18 @@ let rejectRunCallback: ((reason: Error) => void) | undefined
 // genuine mass failure. High enough that a handful of individually bad files
 // still just error and the run continues.
 const MAX_CONSECUTIVE_DISPATCH_FAILURES = 20
+
+// ...and the streak has to have lasted this long. A failed dispatch returns
+// the worker to the pool immediately, so the loop retries at full speed and a
+// rejecting header provider reaches twenty files in milliseconds: on the count
+// alone, a token refresh that blips for a second would tear down a run that
+// used to heal itself. Failures during the window still surface per file, and
+// a consumer that retries them (as the runCuration orchestrator does) loses
+// nothing.
+const MIN_DISPATCH_FAILURE_STREAK_MS = 10_000
 let consecutiveDispatchFailures = 0
+let dispatchFailureStreakStart = 0
+let dispatchFailureReported = false
 
 // Number of replacement workers currently being created asynchronously.
 // The termination condition in dispatchMappingJobs() waits for this to reach 0
@@ -258,6 +269,8 @@ export async function initializeMappingWorkers(
   initFailedWorkers.clear()
   lastInitErrorMessage = ''
   consecutiveDispatchFailures = 0
+  dispatchFailureStreakStart = 0
+  dispatchFailureReported = false
   rejectRunCallback = rejectCb
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
@@ -331,6 +344,7 @@ export async function dispatchMappingJobs(): Promise<void> {
         serializedMappingOptions: serializeMappingOptions(mappingOptions),
       } satisfies MappingRequest)
       consecutiveDispatchFailures = 0
+      dispatchFailureReported = false
     } catch (error) {
       // Same double-recovery guard as recoverCrashedWorker, and for the same
       // reason: this await can outlive its file. The stall watchdog may have
@@ -349,15 +363,24 @@ export async function dispatchMappingJobs(): Promise<void> {
       const message = error instanceof Error ? error.message : String(error)
       failFileAndReturnWorker(mappingWorker, fileInfo, message)
 
-      // Reported once per streak (a success resets the count). The run owner
-      // decides what to do: its rejection tears the pool down, which empties
-      // the queue and ends this loop. With no callback wired the run drains
-      // into error results as before.
+      // Reported once per streak (a success resets it). The run owner decides
+      // what to do: its rejection tears the pool down, which empties the queue
+      // and ends this loop. With no callback wired the run drains into error
+      // results as before.
+      if (consecutiveDispatchFailures === 0) {
+        dispatchFailureStreakStart = Date.now()
+      }
       consecutiveDispatchFailures += 1
-      if (consecutiveDispatchFailures === MAX_CONSECUTIVE_DISPATCH_FAILURES) {
+      const streakDuration = Date.now() - dispatchFailureStreakStart
+      if (
+        !dispatchFailureReported &&
+        consecutiveDispatchFailures >= MAX_CONSECUTIVE_DISPATCH_FAILURES &&
+        streakDuration >= MIN_DISPATCH_FAILURE_STREAK_MS
+      ) {
+        dispatchFailureReported = true
         rejectRunCallback?.(
           new Error(
-            `Dispatch failed for ${MAX_CONSECUTIVE_DISPATCH_FAILURES} consecutive files, last: ${message}`,
+            `Dispatch failed for ${consecutiveDispatchFailures} consecutive files over ${Math.round(streakDuration / 1000)}s, last: ${message}`,
           ),
         )
       }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -68,6 +68,11 @@ let lastWorkerProgressTime = 0
 // before finishing, to avoid orphaning in-flight replacements.
 let pendingReplacements = 0
 
+// Set once the termination condition has emitted 'done'. Guards the whole
+// termination block: re-entering it appends the scan findings a second time to
+// a mapResultsList the consumer already holds a reference to.
+let doneEmitted = false
+
 // Set to true when curateMany is aborted via AbortSignal. Guards dispatch,
 // crash recovery, and worker message handlers against acting on stale state
 // after teardown.
@@ -219,6 +224,7 @@ export async function initializeMappingWorkers(
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
   pendingReplacements = 0
+  doneEmitted = false
   aborted = false
   workerCurrentFile.clear()
   lastWorkerProgressTime = Date.now()
@@ -263,15 +269,39 @@ export async function dispatchMappingJobs(): Promise<void> {
     const { outputTarget, hashMethod, hashPartSize, ...mappingOptions } =
       // Not partial anymore.
       mappingWorkerOptions as TMappingWorkerOptions
-    mappingWorker.postMessage({
-      request: 'apply',
-      fileInfo: await getHttpInputHeaders(fileInfo),
-      outputTarget: await getHttpOutputHeaders(outputTarget),
-      previousFileInfo,
-      hashMethod,
-      hashPartSize,
-      serializedMappingOptions: serializeMappingOptions(mappingOptions),
-    } satisfies MappingRequest)
+
+    // A header provider that rejects (expired credentials, a network failure)
+    // would otherwise leave this file popped and this worker slot consumed for
+    // the rest of the run, so the termination condition could never be met.
+    try {
+      mappingWorker.postMessage({
+        request: 'apply',
+        fileInfo: await getHttpInputHeaders(fileInfo),
+        outputTarget: await getHttpOutputHeaders(outputTarget),
+        previousFileInfo,
+        hashMethod,
+        hashPartSize,
+        serializedMappingOptions: serializeMappingOptions(mappingOptions),
+      } satisfies MappingRequest)
+    } catch (error) {
+      // Same double-recovery guard as recoverCrashedWorker, and for the same
+      // reason: this await can outlive its file. The stall watchdog may have
+      // already recovered the worker, or an abort may have cleared the map --
+      // accounting again would double-count the file, return a terminated
+      // worker to the pool, and drive workersActive to -1.
+      if (!workerCurrentFile.has(mappingWorker)) return
+
+      console.error(
+        'Failed to dispatch file to mapping worker:',
+        error,
+        `File: ${fileInfo.path}/${fileInfo.name}`,
+      )
+      failFileAndReturnWorker(
+        mappingWorker,
+        fileInfo,
+        error instanceof Error ? error.message : String(error),
+      )
+    }
   }
 
   // Backpressure: resume the scan worker when the queue drains below the
@@ -287,11 +317,14 @@ export async function dispatchMappingJobs(): Promise<void> {
   }
 
   if (
+    !doneEmitted &&
     workersActive === 0 &&
     pendingReplacements === 0 &&
     directoryScanFinished &&
     filesToProcess.length === 0
   ) {
+    doneEmitted = true
+
     // End and remove all workers
     while (availableMappingWorkers.length) {
       availableMappingWorkers.pop()!.terminate()
@@ -351,7 +384,7 @@ export async function dispatchMappingJobs(): Promise<void> {
       }
     })
 
-    progressCallback({
+    safeProgress({
       response: 'done',
       mapResultsList: mapResultsList,
       processedFiles: filesMapped,
@@ -363,6 +396,61 @@ export async function dispatchMappingJobs(): Promise<void> {
 // -------------------------------------------------------------------------
 // Internal helpers
 // -------------------------------------------------------------------------
+
+/**
+ * Report progress without letting a consumer throw escape into the pool.
+ *
+ * Reporting sits between `workersActive -= 1` and `dispatchMappingJobs()`,
+ * which is the only place backpressure is released and 'done' is emitted, so an
+ * escaping throw wedges the run -- or, from the 'done' site, becomes an
+ * unhandled rejection, since dispatch is always called unawaited.
+ */
+function safeProgress(message: TProgressMessage): void {
+  try {
+    progressCallback(message)
+  } catch (error) {
+    console.error('Progress callback threw; continuing:', error)
+  }
+}
+
+/**
+ * Account for a file that could not be mapped and return its worker to the
+ * pool, reporting it in the same shape as a worker-reported error.
+ *
+ * Shared by every non-crash failure path, so the pool's invariant holds in one
+ * place: each popped file ends up mapped or errored exactly once, and each
+ * popped worker goes back to the pool.
+ */
+function failFileAndReturnWorker(
+  mappingWorker: Worker,
+  fileInfo: TFileInfo | undefined,
+  errorMessage: string,
+): void {
+  const errorMapResults: TMapResults = {
+    sourceInstanceUID: `error_${filesMapped + 1}`,
+    outputFilePath: '',
+    mappings: {},
+    anomalies: [],
+    errors: [errorMessage],
+    quarantine: {},
+    fileInfo,
+  }
+
+  availableMappingWorkers.push(mappingWorker)
+  workerCurrentFile.delete(mappingWorker)
+  mapResultsList?.push(errorMapResults)
+  workersActive -= 1
+  filesMapped += 1
+
+  safeProgress({
+    response: 'progress',
+    mapResults: errorMapResults,
+    processedFiles: filesMapped,
+    totalFiles:
+      totalDiscoveredFiles ??
+      filesToProcess.length + filesMapped + workersActive,
+  })
+}
 
 /**
  * Return the number of logical CPUs available, working in both browser and
@@ -424,7 +512,7 @@ function recoverCrashedWorker(
   workersActive -= 1
   filesMapped += 1
 
-  progressCallback({
+  safeProgress({
     response: 'progress',
     mapResults: errorMapResults,
     processedFiles: filesMapped,
@@ -433,11 +521,16 @@ function recoverCrashedWorker(
       filesToProcess.length + filesMapped + workersActive,
   })
 
+  // Counted before dispatching: with an empty queue dispatchMappingJobs() runs
+  // straight through to the termination check, so incrementing afterwards lets
+  // 'done' fire while this replacement is in flight -- orphaning the worker it
+  // creates and re-entering the termination block once it joins the pool.
+  pendingReplacements += 1
+
   dispatchMappingJobs()
 
   // Spawn a replacement worker so the pool doesn't shrink permanently.
   // A directory with many problematic files could otherwise kill all workers.
-  pendingReplacements += 1
   void createMappingWorker()
     .then((worker) => {
       pendingReplacements -= 1
@@ -498,6 +591,11 @@ async function createMappingWorker(): Promise<Worker> {
     // Ignore messages from workers after abort — the pool is torn down.
     if (aborted) return
 
+    // Any message from a worker means progress is being made. Recorded before
+    // the lookup/upload branches below so that a consumer upload slower than
+    // the stall timeout is not mistaken for a hung worker.
+    lastWorkerProgressTime = Date.now()
+
     // Handle lookup requests from the worker. The worker sends these when
     // curateOne needs to check if a mapped file was already uploaded
     // (previousMappedFileInfo). The index is kept on the main thread to
@@ -552,12 +650,9 @@ async function createMappingWorker(): Promise<Worker> {
       return
     }
 
-    // Any message from a worker means progress is being made.
-    lastWorkerProgressTime = Date.now()
-    workerCurrentFile.delete(mappingWorker)
-
     switch (event.data.response) {
       case 'finished':
+        workerCurrentFile.delete(mappingWorker)
         availableMappingWorkers.push(mappingWorker)
 
         // Insert null if skipping mapping collection
@@ -566,7 +661,7 @@ async function createMappingWorker(): Promise<Worker> {
         workersActive -= 1
 
         // Report progress
-        progressCallback({
+        safeProgress({
           response: 'progress',
           mapResults: event.data.mapResults,
           processedFiles: filesMapped,
@@ -582,36 +677,26 @@ async function createMappingWorker(): Promise<Worker> {
         break
       case 'error': {
         console.error('Error in mapping worker:', event.data.error)
-        availableMappingWorkers.push(mappingWorker)
-
-        const errorMapResults: TMapResults = {
-          sourceInstanceUID: `error_${filesMapped + 1}`,
-          outputFilePath: '',
-          mappings: {},
-          anomalies: [],
-          errors: [event.data.error.toString()],
-          quarantine: {},
-          fileInfo: event.data.fileInfo,
-        }
-
-        mapResultsList?.push(errorMapResults)
-        workersActive -= 1
-        filesMapped += 1
-
-        progressCallback({
-          response: 'progress',
-          mapResults: errorMapResults,
-          processedFiles: filesMapped,
-          totalFiles:
-            totalDiscoveredFiles ??
-            filesToProcess.length + filesMapped + workersActive,
-        })
+        failFileAndReturnWorker(
+          mappingWorker,
+          event.data.fileInfo,
+          event.data.error.toString(),
+        )
         dispatchMappingJobs()
 
         break
       }
       default:
+        // An unrecognised message says nothing about whether the worker is
+        // still busy, so returning it to the pool risks double-counting its
+        // file when it does reply. Treating the protocol violation as a crash
+        // terminates and replaces it, accounting the file exactly once.
         console.error(`Unknown response from worker ${event.data.response}`)
+        recoverCrashedWorker(
+          mappingWorker,
+          `Unknown response from worker: ${String(event.data.response)}`,
+        )
+        break
     }
   })
 
@@ -638,4 +723,38 @@ export function getWorkersActive(): number {
  */
 export function getLastWorkerProgressTime(): number {
   return lastWorkerProgressTime
+}
+
+/**
+ * Number of replacement workers still being created. Used by the stall
+ * watchdog: the pool's termination condition waits on this, so a run with a
+ * replacement in flight is not finished no matter how idle it looks.
+ */
+export function getPendingReplacements(): number {
+  return pendingReplacements
+}
+
+/**
+ * Number of files still queued for dispatch. Used by the stall watchdog: a
+ * wedged pump leaves work queued with no worker active to drain it.
+ */
+export function getQueueLength(): number {
+  return filesToProcess.length
+}
+
+/**
+ * Whether the directory scan has finished. Used by the stall watchdog to tell
+ * an idle-but-unfinished run from a completed one.
+ */
+export function isDirectoryScanFinished(): boolean {
+  return directoryScanFinished
+}
+
+/**
+ * Restart the stall watchdog's progress baseline after it has taken recovery
+ * action, so a run that stays stuck reports once per timeout rather than once
+ * per watchdog tick.
+ */
+export function resetWorkerProgressTime(): void {
+  lastWorkerProgressTime = Date.now()
 }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -92,14 +92,18 @@ let rejectRunCallback: ((reason: Error) => void) | undefined
 // still just error and the run continues.
 const MAX_CONSECUTIVE_DISPATCH_FAILURES = 20
 
-// ...and the streak has to have lasted this long. A failed dispatch returns
-// the worker to the pool immediately, so the loop retries at full speed and a
-// rejecting header provider reaches twenty files in milliseconds: on the count
-// alone, a token refresh that blips for a second would tear down a run that
-// used to heal itself. Failures during the window still surface per file, and
-// a consumer that retries them (as the runCuration orchestrator does) loses
-// nothing.
+// ...and the streak has to have lasted this long, so that on the count alone a
+// token refresh that blips for a second cannot tear a run down. Files failed
+// during the window surface as plain error results, indistinguishable from a
+// genuinely bad file, so the retry delay below is what bounds the loss.
 const MIN_DISPATCH_FAILURE_STREAK_MS = 10_000
+
+// How long to wait after a failed dispatch while a streak is live. A failed
+// dispatch returns its worker to the pool immediately, so without this the
+// loop burns the whole queue before the streak is old enough to report. At
+// this delay both gates above are reached together, which bounds the damage
+// at roughly MAX_CONSECUTIVE_DISPATCH_FAILURES files per streak.
+const DISPATCH_FAILURE_RETRY_DELAY_MS = 500
 let consecutiveDispatchFailures = 0
 let dispatchFailureStreakStart = 0
 let dispatchFailureReported = false
@@ -383,6 +387,16 @@ export async function dispatchMappingJobs(): Promise<void> {
             `Dispatch failed for ${consecutiveDispatchFailures} consecutive files over ${Math.round(streakDuration / 1000)}s, last: ${message}`,
           ),
         )
+      }
+
+      // Reporting tears the pool down, which clears the queue and ends this
+      // loop, so only an unreported streak is worth slowing down.
+      if (!dispatchFailureReported) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, DISPATCH_FAILURE_RETRY_DELAY_MS),
+        )
+        // The run can be torn down during that wait.
+        if (aborted) return
       }
     }
   }

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -566,6 +566,12 @@ function failFileAndReturnWorker(
   workersActive -= 1
   filesMapped += 1
 
+  // Erroring a file is progress. The worker message listener refreshes this for
+  // its own callers, but the dispatch-failure path never reaches the listener,
+  // so without this a pool steadily turning files into error results looks
+  // completely dead to the stall watchdog.
+  lastMappingProgressTime = Date.now()
+
   safeProgress({
     response: 'progress',
     mapResults: errorMapResults,

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -68,6 +68,22 @@ const workerCurrentFile = new Map<Worker, TFileInfo>()
 let lastMappingProgressTime = 0
 let lastScanProgressTime = 0
 
+// Workers that reported 'initError'. Tracked because the failure can land
+// while initializeMappingWorkers is still assembling the pool, and those
+// workers must not be pushed as dispatchable afterwards.
+const initFailedWorkers = new Set<Worker>()
+let lastInitErrorMessage = ''
+
+// False while initializeMappingWorkers is still assembling the pool: an
+// availableMappingWorkers of zero means nothing then, so the no-workers-left
+// rejection must wait until the pool is complete.
+let poolInitialized = false
+
+// Rejects the whole run. Set by curateMany via initializeMappingWorkers; used
+// when every mapping worker has failed to initialize, since then no dispatch
+// can ever drain the queue and 'done' is unreachable.
+let rejectRunCallback: ((reason: Error) => void) | undefined
+
 // Number of replacement workers currently being created asynchronously.
 // The termination condition in dispatchMappingJobs() waits for this to reach 0
 // before finishing, to avoid orphaning in-flight replacements.
@@ -224,9 +240,14 @@ export async function initializeMappingWorkers(
   fileInfoIndex?: TFileInfoIndex,
   progressCb?: ProgressCallback,
   workerCount?: number,
+  rejectCb?: (reason: Error) => void,
 ): Promise<void> {
   mappingWorkerOptions = {}
   workersActive = 0
+  poolInitialized = false
+  initFailedWorkers.clear()
+  lastInitErrorMessage = ''
+  rejectRunCallback = rejectCb
   mapResultsList = skipCollectingMappings ? undefined : []
   filesMapped = 0
   pendingReplacements = 0
@@ -249,7 +270,13 @@ export async function initializeMappingWorkers(
   const workers = await Promise.all(
     Array.from({ length: effectiveWorkerCount }, () => createMappingWorker()),
   )
-  availableMappingWorkers.push(...workers)
+  // A worker whose 'initError' already arrived was terminated by
+  // handleWorkerInitFailure before this push and must not become dispatchable.
+  availableMappingWorkers.push(
+    ...workers.filter((worker) => !initFailedWorkers.has(worker)),
+  )
+  poolInitialized = true
+  rejectIfNoWorkersLeft()
 }
 
 /**
@@ -563,6 +590,65 @@ function recoverCrashedWorker(
 }
 
 /**
+ * Reject the run once no mapping worker is left to do any work. Only
+ * meaningful after an initialization failure: a busy pool can still recover,
+ * and an empty pool during initializeMappingWorkers is just not assembled yet.
+ */
+function rejectIfNoWorkersLeft(): void {
+  if (!poolInitialized || initFailedWorkers.size === 0) return
+  if (
+    availableMappingWorkers.length > 0 ||
+    workersActive > 0 ||
+    pendingReplacements > 0
+  ) {
+    return
+  }
+  rejectRunCallback?.(
+    new Error(
+      `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
+    ),
+  )
+}
+
+/**
+ * Handle a worker that reported 'initError': its environment never
+ * initialized, so it can never answer a dispatch. Distinct from a crash
+ * because the common case is an idle worker -- the pool has no ready
+ * handshake, so workers become dispatchable before their module has loaded.
+ */
+function handleWorkerInitFailure(mappingWorker: Worker, error: string): void {
+  if (aborted) return
+
+  console.error('Mapping worker failed to initialize:', error)
+  lastInitErrorMessage = error
+  initFailedWorkers.add(mappingWorker)
+
+  // A file was dispatched before the failure surfaced: recover it like any
+  // crash. A pool-wide breakage makes the replacement fail the same way, but
+  // fast, so this converges on the idle path below rather than stalling.
+  if (workerCurrentFile.has(mappingWorker)) {
+    recoverCrashedWorker(
+      mappingWorker,
+      `Mapping worker failed to initialize: ${error}`,
+    )
+    return
+  }
+
+  // Idle worker: remove it so it can never receive a file, and spawn no
+  // replacement -- an environment that cannot initialize a worker will not
+  // do better on retry.
+  const index = availableMappingWorkers.indexOf(mappingWorker)
+  if (index !== -1) availableMappingWorkers.splice(index, 1)
+  try {
+    mappingWorker.terminate()
+  } catch {
+    // Worker may already be terminated
+  }
+
+  rejectIfNoWorkersLeft()
+}
+
+/**
  * Create a single mapping worker with all error/exit/message handlers attached.
  * Used by both initializeMappingWorkers (initial pool) and recoverCrashedWorker
  * (replacement after crash).
@@ -702,6 +788,9 @@ async function createMappingWorker(): Promise<Worker> {
 
         break
       }
+      case 'initError':
+        handleWorkerInitFailure(mappingWorker, event.data.error)
+        break
       default:
         // An unrecognised message says nothing about whether the worker is
         // still busy, so returning it to the pool risks double-counting its

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -362,10 +362,23 @@ export async function dispatchMappingJobs(): Promise<void> {
     // would otherwise leave this file popped and this worker slot consumed for
     // the rest of the run, so the termination condition could never be met.
     try {
+      // Independent providers, and both are per-file round trips on the
+      // dispatch hot path, so they are resolved together rather than in turn.
+      const [inputFileInfo, resolvedOutputTarget] = await Promise.all([
+        getHttpInputHeaders(fileInfo),
+        getHttpOutputHeaders(outputTarget),
+      ])
+
+      // Same double-recovery guard as the failure branch below, and for the
+      // same reason: those awaits can outlive their file. If the stall watchdog
+      // or an abort has already recovered this worker, posting to it now leaves
+      // workersActive incremented for a reply that can never arrive.
+      if (!workerCurrentFile.has(mappingWorker)) continue
+
       mappingWorker.postMessage({
         request: 'apply',
-        fileInfo: await getHttpInputHeaders(fileInfo),
-        outputTarget: await getHttpOutputHeaders(outputTarget),
+        fileInfo: inputFileInfo,
+        outputTarget: resolvedOutputTarget,
         previousFileInfo,
         hashMethod,
         hashPartSize,

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -84,6 +84,11 @@ let poolInitialized = false
 // can ever drain the queue and 'done' is unreachable.
 let rejectRunCallback: ((reason: Error) => void) | undefined
 
+// Ceiling on an explicitly requested worker count. The default path caps itself
+// at 8; this only has to stop a caller's bad arithmetic from spawning threads
+// until the process dies, so it sits well above any real request.
+const MAX_WORKER_COUNT = 64
+
 // Files whose dispatch failed back to back. Header resolution is the usual
 // cause and it runs per file, so one expired token fails every file in turn:
 // unbounded, a 100k-file run turns the whole queue into error results and
@@ -267,18 +272,6 @@ export async function initializeMappingWorkers(
   workerCount?: number,
   rejectCb?: (reason: Error) => void,
 ): Promise<void> {
-  // A count below one builds an empty pool, which can neither dispatch nor
-  // reach the termination condition while files are queued. Rejected rather
-  // than clamped: silently running with one worker would hide the caller bug.
-  if (
-    workerCount !== undefined &&
-    (!Number.isInteger(workerCount) || workerCount < 1)
-  ) {
-    throw new Error(
-      `workerCount must be a positive integer, received ${workerCount}`,
-    )
-  }
-
   mappingWorkerOptions = {}
   workersActive = 0
   poolInitialized = false
@@ -304,6 +297,25 @@ export async function initializeMappingWorkers(
   totalDiscoveredFiles = undefined
 
   if (progressCb) progressCallback = progressCb
+
+  // Validated after the reset above, not before: throwing first left the
+  // previous run's rejectRunCallback and poolInitialized in place, so a
+  // finished run's failure path stayed armed against a pool that no longer
+  // exists. A count below one builds an empty pool, which can neither dispatch
+  // nor reach the termination condition while files are queued; an absurd count
+  // spawns that many threads before the run does any work at all. Rejected
+  // rather than clamped: silently running with a different count would hide the
+  // caller bug.
+  if (
+    workerCount !== undefined &&
+    (!Number.isInteger(workerCount) ||
+      workerCount < 1 ||
+      workerCount > MAX_WORKER_COUNT)
+  ) {
+    throw new Error(
+      `workerCount must be an integer between 1 and ${MAX_WORKER_COUNT}, received ${workerCount}`,
+    )
+  }
 
   const effectiveWorkerCount =
     workerCount ?? Math.min(await getHardwareConcurrency(), 8)

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -267,6 +267,18 @@ export async function initializeMappingWorkers(
   workerCount?: number,
   rejectCb?: (reason: Error) => void,
 ): Promise<void> {
+  // A count below one builds an empty pool, which can neither dispatch nor
+  // reach the termination condition while files are queued. Rejected rather
+  // than clamped: silently running with one worker would hide the caller bug.
+  if (
+    workerCount !== undefined &&
+    (!Number.isInteger(workerCount) || workerCount < 1)
+  ) {
+    throw new Error(
+      `workerCount must be a positive integer, received ${workerCount}`,
+    )
+  }
+
   mappingWorkerOptions = {}
   workersActive = 0
   poolInitialized = false

--- a/src/mappingWorkerPool.ts
+++ b/src/mappingWorkerPool.ts
@@ -287,7 +287,9 @@ export async function initializeMappingWorkers(
     ...workers.filter((worker) => !initFailedWorkers.has(worker)),
   )
   poolInitialized = true
-  rejectIfNoWorkersLeft()
+  rejectIfNoWorkersLeft(
+    `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
+  )
 }
 
 /**
@@ -588,12 +590,44 @@ function recoverCrashedWorker(
   // straight through to the termination check, so incrementing afterwards lets
   // 'done' fire while this replacement is in flight -- orphaning the worker it
   // creates and re-entering the termination block once it joins the pool.
-  pendingReplacements += 1
+  spawnReplacementWorker()
 
   dispatchMappingJobs()
+}
 
-  // Spawn a replacement worker so the pool doesn't shrink permanently.
-  // A directory with many problematic files could otherwise kill all workers.
+/**
+ * Drop an idle worker that broke the message protocol and replace it. It holds
+ * no file, so there is nothing to account -- but leaving it in the pool means
+ * handing it the next one.
+ */
+function retireIdleWorker(mappingWorker: Worker): void {
+  if (aborted) return
+
+  const index = availableMappingWorkers.indexOf(mappingWorker)
+  if (index !== -1) availableMappingWorkers.splice(index, 1)
+  try {
+    mappingWorker.terminate()
+  } catch {
+    // Worker may already be terminated
+  }
+
+  // Before the dispatch, for the reason spelled out in recoverCrashedWorker.
+  spawnReplacementWorker()
+
+  dispatchMappingJobs()
+}
+
+/**
+ * Spawn a replacement for a worker that has left the pool, so the pool doesn't
+ * shrink permanently -- a directory with many problematic files could otherwise
+ * kill every worker.
+ *
+ * Increments pendingReplacements synchronously, so callers must call this
+ * before any dispatch that could otherwise reach the termination check.
+ */
+function spawnReplacementWorker(): void {
+  pendingReplacements += 1
+
   void createMappingWorker()
     .then((worker) => {
       pendingReplacements -= 1
@@ -606,20 +640,33 @@ function recoverCrashedWorker(
       availableMappingWorkers.push(worker)
       dispatchMappingJobs()
     })
-    .catch((error) => {
+    .catch((error: unknown) => {
       console.error('Failed to create replacement worker:', error)
       pendingReplacements -= 1
       dispatchMappingJobs()
+      // Whatever killed the worker can equally stop a new one being built (an
+      // OOM kill takes the thread and the memory to replace it), and this may
+      // have been the last worker. Nothing else notices: the queue keeps its
+      // files and no dispatch can ever run again.
+      rejectIfNoWorkersLeft(
+        `No mapping workers left: a replacement could not be created (${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      )
     })
 }
 
 /**
- * Reject the run once no mapping worker is left to do any work. Only
- * meaningful after an initialization failure: a busy pool can still recover,
- * and an empty pool during initializeMappingWorkers is just not assembled yet.
+ * Reject the run once no mapping worker is left to do any work. Dispatch needs
+ * an available worker and the termination condition needs an empty queue, so
+ * an empty pool with files still queued can satisfy neither: nothing would
+ * ever settle the run again.
+ *
+ * Not meaningful while initializeMappingWorkers is still assembling the pool
+ * (an empty pool then is just one not built yet), nor once the run is over.
  */
-function rejectIfNoWorkersLeft(): void {
-  if (!poolInitialized || initFailedWorkers.size === 0) return
+function rejectIfNoWorkersLeft(reason: string): void {
+  if (!poolInitialized || aborted || doneEmitted) return
   if (
     availableMappingWorkers.length > 0 ||
     workersActive > 0 ||
@@ -627,11 +674,7 @@ function rejectIfNoWorkersLeft(): void {
   ) {
     return
   }
-  rejectRunCallback?.(
-    new Error(
-      `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
-    ),
-  )
+  rejectRunCallback?.(new Error(reason))
 }
 
 /**
@@ -669,7 +712,9 @@ function handleWorkerInitFailure(mappingWorker: Worker, error: string): void {
     // Worker may already be terminated
   }
 
-  rejectIfNoWorkersLeft()
+  rejectIfNoWorkersLeft(
+    `All mapping workers failed to initialize: ${lastInitErrorMessage}`,
+  )
 }
 
 /**
@@ -826,13 +871,19 @@ async function createMappingWorker(): Promise<Worker> {
       default:
         // An unrecognised message says nothing about whether the worker is
         // still busy, so returning it to the pool risks double-counting its
-        // file when it does reply. Treating the protocol violation as a crash
-        // terminates and replaces it, accounting the file exactly once.
+        // file when it does reply. A busy worker is recovered like a crash,
+        // which accounts its file exactly once; an idle one has no file to
+        // account but must still go, since recoverCrashedWorker would ignore
+        // it and leave it in the pool to be handed the next file.
         console.error(`Unknown response from worker ${event.data.response}`)
-        recoverCrashedWorker(
-          mappingWorker,
-          `Unknown response from worker: ${String(event.data.response)}`,
-        )
+        if (workerCurrentFile.has(mappingWorker)) {
+          recoverCrashedWorker(
+            mappingWorker,
+            `Unknown response from worker: ${String(event.data.response)}`,
+          )
+        } else {
+          retireIdleWorker(mappingWorker)
+        }
         break
     }
   })

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -70,6 +70,14 @@ describe('curateMany orchestration with real workers', () => {
     expect(result.processedFiles).toBe(count)
     expect(listFilesRecursive(outputDir)).toHaveLength(count)
 
+    // Truthful end to end: the scanner is still running when the first files
+    // come back, so totalFiles is provisional at that point and exact at 'done'.
+    expect(progress[0].scanComplete).toBe(false)
+    expect(progress.at(-1)).toMatchObject({
+      response: 'done',
+      scanComplete: true,
+    })
+
     // The count must never overshoot the discovered total, in any message —
     // a pause/resume that lost or replayed a file would break this.
     for (const msg of progress) {

--- a/src/orchestration.integration.test.ts
+++ b/src/orchestration.integration.test.ts
@@ -82,6 +82,28 @@ describe('curateMany orchestration with real workers', () => {
     }
   })
 
+  it('completes under backpressure when the consumer callback throws on every message', async () => {
+    const { inputDir, outputDir } = workspace()
+    // The full deadlock: a consumer throw lands between `workersActive -= 1`
+    // and the re-dispatch, and dispatch is the only thing that resumes a
+    // scanner paused on backpressure. One throw used to strand the run.
+    const count = 250
+    await writeImages(inputDir, count)
+
+    const { result } = await runCapturingProgress(
+      integrationOptions(inputDir, outputDir, integrationSpec(), {
+        workerCount: 1,
+      }),
+      () => {
+        throw new Error('consumer callback exploded')
+      },
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(count)
+    expect(listFilesRecursive(outputDir)).toHaveLength(count)
+  })
+
   it('aborts a live run and leaves the input reusable by the next run', async () => {
     const { inputDir, outputDir } = workspace()
     const count = 120

--- a/src/scanDirectoryWorker.ts
+++ b/src/scanDirectoryWorker.ts
@@ -12,10 +12,25 @@ function emit(msg: FileScanMsg): void {
   globalThis.postMessage(msg)
 }
 
-fixupNodeWorkerEnvironment().then(() => {
-  const { handleMessage } = createScanHandler({
-    emit,
-    close: () => globalThis.close(),
+fixupNodeWorkerEnvironment()
+  .then(() => {
+    const { handleMessage } = createScanHandler({
+      emit,
+      close: () => globalThis.close(),
+    })
+    globalThis.addEventListener('message', handleMessage)
   })
-  globalThis.addEventListener('message', handleMessage)
-})
+  .catch((error) => {
+    // Without this the worker never installs its message listener and the
+    // scan request is silently dropped, leaving curateMany waiting forever.
+    // Reported as a scan error so index.ts rejects the run. Falls back to a
+    // log if postMessage is missing.
+    const message = `Failed to initialize scan worker environment: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+    try {
+      emit({ response: 'error', error: message })
+    } catch {
+      console.error(message, error)
+    }
+  })

--- a/src/scanDirectoryWorker.ts
+++ b/src/scanDirectoryWorker.ts
@@ -22,15 +22,24 @@ fixupNodeWorkerEnvironment()
   })
   .catch((error) => {
     // Without this the worker never installs its message listener and the
-    // scan request is silently dropped, leaving curateMany waiting forever.
-    // Reported as a scan error so index.ts rejects the run. Falls back to a
-    // log if postMessage is missing.
+    // scan request is silently dropped, leaving curateMany waiting forever --
+    // and with no listener the thread exits with code 0, which index.ts's
+    // exit handler reads as a normal exit. Reported as a scan error so the
+    // run is rejected instead.
     const message = `Failed to initialize scan worker environment: ${
       error instanceof Error ? error.message : String(error)
     }`
+    console.error(message, error)
+    const msg: FileScanMsg = { response: 'error', error: message }
     try {
-      emit({ response: 'error', error: message })
+      emit(msg)
     } catch {
-      console.error(message, error)
+      // Under Node the rejection happens before fixupNodeWorkerEnvironment()
+      // installs globalThis.postMessage, so emit() itself throws. Go direct,
+      // matching the { data } wrapping the fixup applies (see worker.ts). If
+      // worker_threads was itself the failure, the log above is the last word.
+      void import('worker_threads')
+        .then(({ parentPort }) => parentPort?.postMessage({ data: msg }))
+        .catch(() => {})
     }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,8 @@ export type OrganizeOptions = {
   // Example: ['**/logs/**'] excludes any file under a 'logs' directory.
   // Uses picomatch glob syntax.
   excludedPathGlobs?: string[]
-  // Maximum number of concurrent mapping workers. Must be a positive integer.
+  // Maximum number of concurrent mapping workers. Must be an integer between
+  // 1 and 64; anything else is rejected rather than clamped.
   // Defaults to the platform's hardware concurrency (capped at 8).
   // Reducing this limits peak memory usage at the cost of slower throughput.
   workerCount?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -422,6 +422,9 @@ export type TCurationSpecification<THost extends HostProps = HostProps> = {
 type TProgressMessageBase = {
   totalFiles?: number
   processedFiles?: number
+  // Whether the directory scan has finished. Until it has, `totalFiles` is a
+  // lower bound the scanner is still revising, not an exact denominator.
+  scanComplete?: boolean
 }
 
 type TProgressMessageProgress = TProgressMessageBase & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export type OrganizeOptions = {
   // Example: ['**/logs/**'] excludes any file under a 'logs' directory.
   // Uses picomatch glob syntax.
   excludedPathGlobs?: string[]
-  // Maximum number of concurrent mapping workers.
+  // Maximum number of concurrent mapping workers. Must be a positive integer.
   // Defaults to the platform's hardware concurrency (capped at 8).
   // Reducing this limits peak memory usage at the cost of slower throughput.
   workerCount?: number

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -447,6 +447,112 @@ describe('worker crash recovery', () => {
     errorSpy.mockRestore()
   }, 30_000)
 
+  it('rejects the run when every mapping worker fails to initialize', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('init-error'))
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    await expect(curatePromise).rejects.toThrow(
+      /All mapping workers failed to initialize/,
+    )
+
+    expect(getMockWorkersCreated().every((w) => w.terminated)).toBe(true)
+    expect(pool.availableMappingWorkers.length).toBe(0)
+
+    // Here the failures land after setup created the scan worker, so failRun
+    // is what tears it down.
+    expect(scanWorkerInstance?.terminated ?? true).toBe(true)
+  })
+
+  it('starts no scan when the pool fails during assembly', async () => {
+    configureMockMappingWorkers(
+      Array(WORKER_COUNT).fill('init-error-immediate'),
+    )
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    await expect(curatePromise).rejects.toThrow(
+      /All mapping workers failed to initialize/,
+    )
+
+    // The rejection lands before setup reaches the scan worker. Since failRun
+    // and the abort handler are both settled-guarded, a worker created past
+    // that point could never be terminated -- it would scan the whole tree
+    // for a dead run and hold the Node event loop open.
+    expect(scanWorkerInstance).toBeUndefined()
+  })
+
+  it('drops an idle worker that fails to initialize and completes with the rest', async () => {
+    configureMockMappingWorkers(makeBehaviors('init-error'))
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+
+    // The failed worker never received a file, so nothing was errored, and
+    // no replacement was spawned for it (total created == initial pool).
+    const errors = result.mapResultsList!.filter(
+      (r) => r.errors && r.errors.length > 0,
+    )
+    expect(errors).toHaveLength(0)
+    expect(getMockWorkersCreated().length).toBe(WORKER_COUNT)
+  })
+
+  it('recovers a worker whose init failure surfaces after a file was dispatched', async () => {
+    configureMockMappingWorkers(makeBehaviors('init-error-on-apply'))
+
+    const result = await curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+
+    // The in-flight file was accounted exactly once, as a crash-style error.
+    const initErrors = result.mapResultsList!.filter((r) =>
+      r.errors?.some((e) => e.includes('failed to initialize')),
+    )
+    expect(initErrors).toHaveLength(1)
+
+    // The broken worker was replaced so the pool did not shrink.
+    expect(getMockWorkersCreated().length).toBeGreaterThan(WORKER_COUNT)
+  })
+
   it('emits done once when the last worker crashes at end of run', async () => {
     const singleFileDir = createTestDicomDir(1)
 

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -553,6 +553,54 @@ describe('worker crash recovery', () => {
     expect(getMockWorkersCreated().length).toBeGreaterThan(WORKER_COUNT)
   })
 
+  it('rejects the run when the scan worker exits without an error event', async () => {
+    vi.useFakeTimers()
+
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    // Setup finishes without advancing timers, so the scan has emitted
+    // nothing -- then kill the thread as an OOM does: 'exit' and nothing more.
+    await flushMicrotasks(20)
+    scanWorkerInstance!.emitExit(1)
+
+    await expect(curatePromise).rejects.toThrow(
+      /Scan worker exited unexpectedly with code 1/,
+    )
+  })
+
+  it('ignores a normal scan worker exit', async () => {
+    configureMockMappingWorkers(Array(WORKER_COUNT).fill('normal'))
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: WORKER_COUNT,
+      },
+      () => {},
+    )
+
+    await waitFor(() => scanWorkerInstance !== undefined)
+    scanWorkerInstance!.emitExit(0)
+
+    const result = await curatePromise
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(10)
+  })
+
   it('emits done once when the last worker crashes at end of run', async () => {
     const singleFileDir = createTestDicomDir(1)
 

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -451,6 +451,44 @@ describe('worker crash recovery', () => {
     errorSpy.mockRestore()
   }, 30_000)
 
+  // The mirror image of the test above: a scanner that stops reporting has
+  // nothing for the watchdog to recover and nothing to re-dispatch, so
+  // detecting the stall is all it can do -- and detection alone leaves the run
+  // waiting forever.
+  it('rejects the run when the scanner stops reporting', async () => {
+    vi.useFakeTimers()
+
+    configureMockMappingWorkers(['normal'])
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: 1,
+      },
+      () => {},
+    )
+
+    await flushMicrotasks(20)
+
+    // Kill the scanner before it emits anything: no files queued, no worker
+    // active, no 'done' -- the run is left waiting on a scanner that will
+    // never speak again. (A real one wedges rather than dies, which is why the
+    // 'exit' handler cannot cover this.)
+    scanWorkerInstance!.terminate()
+
+    for (let i = 0; i < 11; i++) {
+      vi.advanceTimersByTime(60 * 1000)
+      await flushMicrotasks()
+    }
+
+    await expect(curatePromise).rejects.toThrow(
+      /Scan worker stopped reporting progress/,
+    )
+  }, 30_000)
+
   it('rejects the run when every mapping worker fails to initialize', async () => {
     configureMockMappingWorkers(Array(WORKER_COUNT).fill('init-error'))
 

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -353,7 +353,7 @@ describe('worker crash recovery', () => {
   it('does not let scan activity mask a stalled mapping pump', async () => {
     vi.useFakeTimers()
 
-    configureMockMappingWorkers(['normal'])
+    configureMockMappingWorkers(['hang'])
 
     const curatePromise = curateMany(
       {
@@ -368,26 +368,26 @@ describe('worker crash recovery', () => {
 
     await flushMicrotasks(20)
 
-    // Same injected wedge as the test above -- work queued, nothing active,
-    // no dispatch pending -- but this time the scanner keeps reporting in
-    // throughout the stall. In reality the file counter runs even while
-    // paused for backpressure, so it must not be able to stand in for
-    // mapping progress: with work outstanding, only mapping activity counts.
-    scanWorkerInstance!.terminate()
-    pool.filesToProcess.push(
-      queuedFile('wedged-1.dcm'),
-      queuedFile('wedged-2.dcm'),
-    )
-    pool.setDirectoryScanFinished(true)
-
-    for (let i = 0; i < 12; i++) {
-      vi.advanceTimersByTime(60 * 1000)
-      pool.resetScanProgressTime()
+    // Let the scan emit its files and the single (hanging) worker swallow the
+    // first one: mapping work is now outstanding and no mapping message will
+    // ever arrive.
+    for (let i = 0; i < 200; i++) {
+      vi.advanceTimersByTime(1)
       await flushMicrotasks()
     }
 
-    // Let the re-pumped dispatch and the worker responses drain.
-    for (let i = 0; i < 50; i++) {
+    // The scanner keeps reporting in every minute, as real 'count' messages
+    // through the scan-worker message handler. Its file counter runs even
+    // while paused for backpressure, so it must never stand in for mapping
+    // progress: with work outstanding, only mapping activity counts.
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(60 * 1000)
+      scanWorkerInstance!.emitCount(10)
+      await flushMicrotasks()
+    }
+
+    // Let the recovery, replacement worker, and remaining files drain.
+    for (let i = 0; i < 100; i++) {
       vi.advanceTimersByTime(1)
       await flushMicrotasks()
     }
@@ -395,7 +395,11 @@ describe('worker crash recovery', () => {
     const result = await curatePromise
 
     expect(result.response).toBe('done')
-    expect(result.processedFiles).toBe(2)
+    expect(result.processedFiles).toBe(10)
+    const stallErrors = result.mapResultsList!.filter((r) =>
+      r.errors?.some((e) => e.includes('stalled')),
+    )
+    expect(stallErrors.length).toBe(1)
   }, 30_000)
 
   it('does not false-fire on a healthy scan with nothing dispatched yet', async () => {
@@ -423,7 +427,7 @@ describe('worker crash recovery', () => {
     // as the scanner keeps reporting in.
     for (let i = 0; i < 12; i++) {
       vi.advanceTimersByTime(60 * 1000)
-      pool.resetScanProgressTime()
+      scanWorkerInstance!.emitCount(0)
       await flushMicrotasks()
     }
 

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -350,6 +350,103 @@ describe('worker crash recovery', () => {
     expect(result.processedFiles).toBe(2)
   }, 30_000)
 
+  it('does not let scan activity mask a stalled mapping pump', async () => {
+    vi.useFakeTimers()
+
+    configureMockMappingWorkers(['normal'])
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: 1,
+      },
+      () => {},
+    )
+
+    await flushMicrotasks(20)
+
+    // Same injected wedge as the test above -- work queued, nothing active,
+    // no dispatch pending -- but this time the scanner keeps reporting in
+    // throughout the stall. In reality the file counter runs even while
+    // paused for backpressure, so it must not be able to stand in for
+    // mapping progress: with work outstanding, only mapping activity counts.
+    scanWorkerInstance!.terminate()
+    pool.filesToProcess.push(
+      queuedFile('wedged-1.dcm'),
+      queuedFile('wedged-2.dcm'),
+    )
+    pool.setDirectoryScanFinished(true)
+
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(60 * 1000)
+      pool.resetScanProgressTime()
+      await flushMicrotasks()
+    }
+
+    // Let the re-pumped dispatch and the worker responses drain.
+    for (let i = 0; i < 50; i++) {
+      vi.advanceTimersByTime(1)
+      await flushMicrotasks()
+    }
+
+    const result = await curatePromise
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(2)
+  }, 30_000)
+
+  it('does not false-fire on a healthy scan with nothing dispatched yet', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error')
+
+    configureMockMappingWorkers(['normal'])
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: 1,
+      },
+      () => {},
+    )
+
+    await flushMicrotasks(20)
+
+    // Nothing queued, nothing active, scan not finished -- purely waiting on
+    // the scanner. A deep tree of excluded files or a slow remote listing
+    // looks exactly like this, and must not be reported as a stall as long
+    // as the scanner keeps reporting in.
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(60 * 1000)
+      pool.resetScanProgressTime()
+      await flushMicrotasks()
+    }
+
+    expect(
+      errorSpy.mock.calls.some((call) =>
+        String(call[0]).includes('Stall detected'),
+      ),
+    ).toBe(false)
+
+    // Let the scan actually finish so the run can settle.
+    scanWorkerInstance!.terminate()
+    pool.setDirectoryScanFinished(true)
+    for (let i = 0; i < 50; i++) {
+      vi.advanceTimersByTime(1)
+      await flushMicrotasks()
+    }
+
+    const result = await curatePromise
+    expect(result.response).toBe('done')
+
+    errorSpy.mockRestore()
+  }, 30_000)
+
   it('emits done once when the last worker crashes at end of run', async () => {
     const singleFileDir = createTestDicomDir(1)
 
@@ -374,7 +471,7 @@ describe('worker crash recovery', () => {
       // so recovery runs with an empty queue - the end-of-run case where the
       // termination condition is already satisfied.
       await waitFor(
-        () => pool.directoryScanFinished && pool.getWorkersActive() === 1,
+        () => pool.isDirectoryScanFinished() && pool.getWorkersActive() === 1,
       )
 
       // A hard scan read-failure is reported from the termination block, so a

--- a/src/workerCrashRecovery.test.ts
+++ b/src/workerCrashRecovery.test.ts
@@ -29,7 +29,7 @@ import {
   resetMockWorkers,
 } from '../testutils/mockMappingWorker'
 import { MockScanWorker } from '../testutils/mockScanWorker'
-import type { TCurationSpecification } from './types'
+import type { TCurationSpecification, TProgressMessage } from './types'
 
 let scanWorkerInstance: MockScanWorker | undefined
 
@@ -51,6 +51,9 @@ vi.doMock('./worker', () => ({
 }))
 
 const { curateMany } = await import('./index')
+// Imported alongside curateMany so a test can drive the pool into states the
+// public API can no longer produce -- the wedge the watchdog exists to break.
+const pool = await import('./mappingWorkerPool')
 
 const WORKER_COUNT = Math.max(3, Math.min(cpus().length || 1, 8))
 
@@ -63,6 +66,37 @@ function makeBehaviors(
   ).fill('normal')
   // Crash workers go last so they're popped first from the LIFO stack
   return [...normals, ...crashBehaviors]
+}
+
+async function flushMicrotasks(rounds = 1): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+}
+
+/** Let any already-scheduled setTimeout(0) work run to completion. */
+async function settle(): Promise<void> {
+  for (let tick = 0; tick < 10; tick++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+/** Drive real timers until `predicate` holds; the mock workers reply on setTimeout(0). */
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let tick = 0; tick < 500; tick++) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('waitFor: condition was never met')
+}
+
+function queuedFile(name: string) {
+  return {
+    fileInfo: { kind: 'path', path: '/wedged', name, size: 1 } as any,
+    scanAnomalies: [],
+  }
 }
 
 function minimalSpec() {
@@ -265,5 +299,119 @@ describe('worker crash recovery', () => {
       r.errors?.some((e) => e.includes('stalled')),
     )
     expect(stallErrors.length).toBeGreaterThanOrEqual(1)
+  }, 30_000)
+
+  it('stall watchdog re-pumps a stalled dispatch with no active workers', async () => {
+    vi.useFakeTimers()
+
+    configureMockMappingWorkers(['normal'])
+
+    const curatePromise = curateMany(
+      {
+        inputType: 'path',
+        inputDirectory: testDir,
+        curationSpec: minimalSpec,
+        skipWrite: true,
+        workerCount: 1,
+      },
+      () => {},
+    )
+
+    // Let the async setup finish without advancing any timer, so the scan
+    // worker never emits.
+    await flushMicrotasks(20)
+
+    // Reproduce the wedge a killed pump leaves behind: work queued, scan
+    // finished, nothing active and no dispatch pending. Injected rather than
+    // provoked, because the pump can no longer be killed from a callback.
+    scanWorkerInstance!.terminate()
+    pool.filesToProcess.push(
+      queuedFile('wedged-1.dcm'),
+      queuedFile('wedged-2.dcm'),
+    )
+    pool.setDirectoryScanFinished(true)
+
+    // The previous gate (workersActive > 0) could never fire in this state,
+    // so the run hung here indefinitely.
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(60 * 1000)
+      await flushMicrotasks()
+    }
+
+    // Let the re-pumped dispatch and the worker responses drain.
+    for (let i = 0; i < 50; i++) {
+      vi.advanceTimersByTime(1)
+      await flushMicrotasks()
+    }
+
+    const result = await curatePromise
+
+    expect(result.response).toBe('done')
+    expect(result.processedFiles).toBe(2)
+  }, 30_000)
+
+  it('emits done once when the last worker crashes at end of run', async () => {
+    const singleFileDir = createTestDicomDir(1)
+
+    try {
+      configureMockMappingWorkers(['hang'])
+
+      const doneMessages: TProgressMessage[] = []
+      const curatePromise = curateMany(
+        {
+          inputType: 'path',
+          inputDirectory: singleFileDir,
+          curationSpec: minimalSpec,
+          skipWrite: true,
+          workerCount: 1,
+        },
+        (msg) => {
+          if (msg.response === 'done') doneMessages.push(msg)
+        },
+      )
+
+      // Crash only once the sole file is in flight and the scan has finished,
+      // so recovery runs with an empty queue - the end-of-run case where the
+      // termination condition is already satisfied.
+      await waitFor(
+        () => pool.directoryScanFinished && pool.getWorkersActive() === 1,
+      )
+
+      // A hard scan read-failure is reported from the termination block, so a
+      // second pass through it appends this entry to mapResultsList twice.
+      pool.scanAnomalies.push({
+        fileInfo: {
+          kind: 'path',
+          path: singleFileDir,
+          name: 'unreadable.dcm',
+        } as any,
+        anomalies: [],
+        errors: ['Simulated read failure'],
+      })
+
+      const [crashed] = getMockWorkersCreated()
+      crashed.onerror!({ message: 'Simulated end-of-run crash' })
+
+      const result = await curatePromise
+
+      // Give the replacement worker time to be created and dispatched: doing
+      // that after 'done' rather than before can produce duplicates.
+      await settle()
+      expect(getMockWorkersCreated()).toHaveLength(2)
+
+      expect(result.response).toBe('done')
+      expect(doneMessages).toHaveLength(1)
+      expect(
+        result.mapResultsList!.filter((r) =>
+          r.sourceInstanceUID.startsWith('scan_'),
+        ),
+      ).toHaveLength(1)
+      expect(result.mapResultsList).toHaveLength(2)
+
+      // Torn down with the pool rather than left running past the run.
+      expect(getMockWorkersCreated()[1].terminated).toBe(true)
+    } finally {
+      cleanupTestDicomDir(singleFileDir)
+    }
   }, 30_000)
 })

--- a/testutils/mockMappingWorker.ts
+++ b/testutils/mockMappingWorker.ts
@@ -13,6 +13,9 @@ export type MockWorkerBehavior =
   | 'crash-onerror-and-exit'
   | 'hang'
   | 'unknown-response'
+  // Emits an unrecognised message while sitting idle in the pool, before it
+  // has been given any file.
+  | 'unknown-response-idle'
   // Emits 'initError' shortly after creation, while idle in the pool.
   | 'init-error'
   // Emits 'initError' as the pool attaches its message listener, i.e. while
@@ -54,6 +57,16 @@ export class MockWorker {
 
   constructor(behavior: MockWorkerBehavior) {
     this.behavior = behavior
+
+    if (behavior === 'unknown-response-idle') {
+      // Same setTimeout(0) reason as 'init-error' below: the pool attaches its
+      // message listener synchronously inside createMappingWorker.
+      setTimeout(() => {
+        if (!this.terminated) {
+          this.emitMessage({ response: 'heartbeat' })
+        }
+      }, 0)
+    }
 
     if (behavior === 'init-error') {
       // setTimeout(0) so the pool has attached its message listener (that

--- a/testutils/mockMappingWorker.ts
+++ b/testutils/mockMappingWorker.ts
@@ -169,10 +169,11 @@ export class MockWorker {
         setTimeout(() => {
           if (this.terminated) return
           this.emitMessage({ response: 'heartbeat' })
+          // Emitted even though the pool has terminated this worker by now:
+          // models a reply already queued on the parent's port when terminate
+          // landed, which is what the pool's completion guards exist for.
           setTimeout(() => {
-            if (!this.terminated) {
-              this.emitMessage({ response: 'finished', mapResults })
-            }
+            this.emitMessage({ response: 'finished', mapResults })
           }, 0)
         }, 0)
         break

--- a/testutils/mockMappingWorker.ts
+++ b/testutils/mockMappingWorker.ts
@@ -13,6 +13,13 @@ export type MockWorkerBehavior =
   | 'crash-onerror-and-exit'
   | 'hang'
   | 'unknown-response'
+  // Emits 'initError' shortly after creation, while idle in the pool.
+  | 'init-error'
+  // Emits 'initError' as the pool attaches its message listener, i.e. while
+  // initializeMappingWorkers is still assembling the pool.
+  | 'init-error-immediate'
+  // Emits 'initError' in response to the first file it is given.
+  | 'init-error-on-apply'
 
 let mockBehaviors: MockWorkerBehavior[] = []
 let mockWorkerIndex = 0
@@ -47,11 +54,32 @@ export class MockWorker {
 
   constructor(behavior: MockWorkerBehavior) {
     this.behavior = behavior
+
+    if (behavior === 'init-error') {
+      // setTimeout(0) so the pool has attached its message listener (that
+      // happens synchronously within createMappingWorker) before this fires.
+      setTimeout(() => {
+        if (!this.terminated) {
+          this.emitMessage({
+            response: 'initError',
+            error: 'Simulated worker init failure',
+          })
+        }
+      }, 0)
+    }
   }
 
   addEventListener(event: string, listener: any): void {
     if (event === 'message') {
       this.messageListeners.push(listener)
+      if (this.behavior === 'init-error-immediate') {
+        listener({
+          data: {
+            response: 'initError',
+            error: 'Simulated worker init failure',
+          },
+        })
+      }
     }
   }
 
@@ -146,6 +174,17 @@ export class MockWorker {
               this.emitMessage({ response: 'finished', mapResults })
             }
           }, 0)
+        }, 0)
+        break
+      }
+      case 'init-error-on-apply': {
+        setTimeout(() => {
+          if (!this.terminated) {
+            this.emitMessage({
+              response: 'initError',
+              error: 'Simulated worker init failure',
+            })
+          }
         }, 0)
         break
       }

--- a/testutils/mockMappingWorker.ts
+++ b/testutils/mockMappingWorker.ts
@@ -12,6 +12,7 @@ export type MockWorkerBehavior =
   | 'crash-exit'
   | 'crash-onerror-and-exit'
   | 'hang'
+  | 'unknown-response'
 
 let mockBehaviors: MockWorkerBehavior[] = []
 let mockWorkerIndex = 0
@@ -121,6 +122,30 @@ export class MockWorker {
               listener(1)
             }
           }
+        }, 0)
+        break
+      }
+      // Replies with a message the pool has no case for, then finishes the
+      // file normally. Models a worker that is still busy when the unknown
+      // message arrives, so returning it to the pool would double-count.
+      case 'unknown-response': {
+        const mapResults = {
+          sourceInstanceUID: fileInfo?.name || 'unknown',
+          outputFilePath: `output/${fileInfo?.name || 'unknown'}`,
+          mappings: {},
+          anomalies: [],
+          errors: [],
+          quarantine: {},
+          fileInfo,
+        }
+        setTimeout(() => {
+          if (this.terminated) return
+          this.emitMessage({ response: 'heartbeat' })
+          setTimeout(() => {
+            if (!this.terminated) {
+              this.emitMessage({ response: 'finished', mapResults })
+            }
+          }, 0)
         }, 0)
         break
       }

--- a/testutils/mockScanWorker.ts
+++ b/testutils/mockScanWorker.ts
@@ -27,6 +27,7 @@ export class MockScanWorker {
   public terminated = false
 
   private messageListeners: ((event: { data: any }) => void)[] = []
+  private exitListeners: ((code: number) => void)[] = []
   private pendingEmitTimeout: ReturnType<typeof setTimeout> | null = null
 
   addEventListener(event: string, listener: any): void {
@@ -38,6 +39,21 @@ export class MockScanWorker {
   on(event: string, listener: any): void {
     if (event === 'message') {
       this.messageListeners.push(listener)
+    } else if (event === 'exit') {
+      this.exitListeners.push(listener)
+    }
+  }
+
+  /** Emit a 'count' message, as the real scanner does while counting ahead. */
+  emitCount(totalDiscovered: number): void {
+    if (this.terminated) return
+    this.emit({ response: 'count', totalDiscovered })
+  }
+
+  /** Simulate the worker thread exiting, as Node's 'exit' event reports it. */
+  emitExit(code: number): void {
+    for (const listener of this.exitListeners) {
+      listener(code)
     }
   }
 


### PR DESCRIPTION
# Stop `curateMany` hanging forever

Fixes #280

Confirmed not to affect pre-existing curation specs

Background: 
-  a ~105k-file run that sat at a plausible 68% for 4h47m and never completed. Closes every never-settle mechanism found in the 'pump'.

## The wedge

At three pump sites the order was `workersActive -= 1` → unguarded `progressCallback(...)` → `dispatchMappingJobs()`. One consumer throw kills the pump, and since the scanner's backpressure resume lives *inside* `dispatchMappingJobs`, the scanner stays paused too. The stall watchdog was gated on `getWorkersActive() > 0` and its recovery iterated an already-cleared  map - i.e. blind to this state.

## From the (internal*) issues list

**C1** :  New `safeProgress()` wraps every consumer callback; dispatch now runs exactly once per completion whatever the consumer does. Also covers the `done` emission, which sits inside `async dispatchMappingJobs` with every caller fire-and-forget — a throw there was an unhandled rejection, process-fatal on Node ≥15, i.e. it would crash dcr at the end of an otherwise-successful run

**C2** : Watchdog re-gated on the pool's full termination condition (active workers, queued files, unfinished scan, or pending replacements) and now always re-pumps `dispatchMappingJobs()`, which also breaks a DEV-82*-style lost dispatch. `lastWorkerProgressTime` moved above the lookup/upload early returns so slow consumer uploads aren't killed at 10 min, and scan-worker activity counts as progress so a long run of excluded files isn't misreported as a stall

**C3** : `scanComplete` on progress messages so consumers can stop rendering a % against a denominator the scanner is still revising. Engine half of A4 — pick up in ProgressStatusBar once on 0.42.0 |

## Also found incidentatlly, and fixed

| Fix | Why it matters |
|---|---|
| **Header-provider rejection leaked a worker slot** (#280) | Each rejection permanently consumed a slot and lost a file → `done` unreachable. Now: file errored, worker returned, run continues. Carries the same guard as `recoverCrashedWorker`, so a rejection landing after the watchdog already recovered that worker can't double-account it |
| **Unknown worker response leaked a slot** | Now treated as a protocol failure: terminate and replace. An unknown message says nothing about whether the worker is still busy — returning it to the pool risks counting its file twice and driving `workersActive` negative, past which the termination check can never hold |
| **A throwing consumer could stop `curateMany` resolving** | `resolve` now precedes `onProgress`, `onProgress` is wrapped, and `done` is forwarded at most once |
| **Duplicate `done` after an end-of-run crash** | `pendingReplacements` was incremented *after* the dispatch that checks it, so a last-worker crash fired `done` early, then the replacement's dispatch fired a second `done` — re-running the scan-findings loop and appending duplicates to a `mapResultsList` the consumer already held (and, in the creation-failure/abort edge, leaking the replacement thread). Reordered, plus a `doneEmitted` guard making the termination block idempotent at source |
| **`inputType: 'files'` never settled** | `queueFilesForMapping` never marked the scan finished, so the termination check was unsatisfiable — a documented public input type that hangs after processing every file, previously with zero test coverage. One line |
| **Scan worker init had no `.catch`** | A failed environment shim silently dropped the scan request; the browser hung with no error. Now emits a scan error into the existing reject path |

## Tests

Every fix has a regression test, each confirmed to fail against the
pre-changed implementation 